### PR TITLE
fix(eas): correct Slack workflow param and success/failure conditionals

### DIFF
--- a/mobile/.eas/workflows/deploy.yml
+++ b/mobile/.eas/workflows/deploy.yml
@@ -25,42 +25,35 @@ jobs:
       platform: ios
       profile: production
 
-  notify_slack_success:
-    name: Notify Slack (Success)
-    after: [build_android, build_ios]
+  notify_success:
+    name: Share Production Build Links
+    needs: [build_android, build_ios]
+    if: ${{ success() }}
     environment: production
-    if: ${{ after.build_android.status == 'finished' && after.build_ios.status == 'finished' }}
     steps:
       - uses: eas/send_slack_message
         with:
+          slack_hook_url: ${{ env.SLACK_HOOK_URL_SUCCESS }}
           message: |
-            Production build succeeded.
-            Workflow: ${{ workflow.name }}
-            Branch: ${{ inputs.branch }}
-            Android version: ${{ after.build_android.outputs.app_version }}
-            Android build: ${{ after.build_android.status }}
-            Android build URL: https://expo.dev/builds/${{ after.build_android.outputs.build_id }}
-            iOS version: ${{ after.build_ios.outputs.app_version }}
-            iOS build: ${{ after.build_ios.status }}
-            iOS build URL: https://expo.dev/builds/${{ after.build_ios.outputs.build_id }}
-            Workflow URL: ${{ workflow.url }}
-          url: ${{ env.SLACK_HOOK_URL_SUCCESS }}
+            Production builds are ready.
 
-  notify_slack_failure:
-    name: Notify Slack (Failure)
+            Android version: ${{ needs.build_android.outputs.app_version }}
+            Android build link: https://expo.dev/builds/${{ needs.build_android.outputs.build_id }}
+
+            iOS version: ${{ needs.build_ios.outputs.app_version }}
+            iOS build link: https://expo.dev/builds/${{ needs.build_ios.outputs.build_id }}
+
+  notify_failure:
+    name: Notify Production Build Failure
     after: [build_android, build_ios]
+    if: ${{ failure() }}
     environment: production
-    if: ${{ after.build_android.status != 'finished' || after.build_ios.status != 'finished' }}
     steps:
       - uses: eas/send_slack_message
         with:
+          slack_hook_url: ${{ env.SLACK_HOOK_URL_FAILURE }}
           message: |
             Production build failed.
+
             Workflow: ${{ workflow.name }}
-            Branch: ${{ inputs.branch }}
-            Android build: ${{ after.build_android.status }}
-            Android build URL: https://expo.dev/builds/${{ after.build_android.outputs.build_id }}
-            iOS build: ${{ after.build_ios.status }}
-            iOS build URL: https://expo.dev/builds/${{ after.build_ios.outputs.build_id }}
-            Workflow URL: ${{ workflow.url }}
-          url: ${{ env.SLACK_HOOK_URL_FAILURE }}
+            Details: ${{ workflow.url }}

--- a/mobile/.eas/workflows/deploy_android.yml
+++ b/mobile/.eas/workflows/deploy_android.yml
@@ -17,37 +17,34 @@ jobs:
       platform: android
       profile: production
 
-  notify_slack_success:
-    name: Notify Slack (Success)
-    after: [build_android]
+  notify_success:
+    name: Share Android Production Link
+    needs: [build_android]
+    if: ${{ success() }}
     environment: production
-    if: ${{ after.build_android.status == 'finished' }}
     steps:
       - uses: eas/send_slack_message
         with:
+          slack_hook_url: ${{ env.SLACK_HOOK_URL_SUCCESS }}
           message: |
-            Android production build succeeded.
-            Workflow: ${{ workflow.name }}
-            Branch: ${{ inputs.branch }}
-            Version: ${{ after.build_android.outputs.app_version }}
-            Build status: ${{ after.build_android.status }}
-            Build URL: https://expo.dev/builds/${{ after.build_android.outputs.build_id }}
-            Workflow URL: ${{ workflow.url }}
-          url: ${{ env.SLACK_HOOK_URL_SUCCESS }}
+            Android production build is ready.
 
-  notify_slack_failure:
-    name: Notify Slack (Failure)
+            App: ${{ needs.build_android.outputs.app_identifier }}
+            Version: ${{ needs.build_android.outputs.app_version }}
+            Build number: ${{ needs.build_android.outputs.app_build_version }}
+            Build link: https://expo.dev/builds/${{ needs.build_android.outputs.build_id }}
+
+  notify_failure:
+    name: Notify Android Production Failure
     after: [build_android]
+    if: ${{ failure() }}
     environment: production
-    if: ${{ after.build_android.status != 'finished' }}
     steps:
       - uses: eas/send_slack_message
         with:
+          slack_hook_url: ${{ env.SLACK_HOOK_URL_FAILURE }}
           message: |
             Android production build failed.
+
             Workflow: ${{ workflow.name }}
-            Branch: ${{ inputs.branch }}
-            Build status: ${{ after.build_android.status }}
-            Build URL: https://expo.dev/builds/${{ after.build_android.outputs.build_id }}
-            Workflow URL: ${{ workflow.url }}
-          url: ${{ env.SLACK_HOOK_URL_FAILURE }}
+            Details: ${{ workflow.url }}

--- a/mobile/.eas/workflows/deploy_ios.yml
+++ b/mobile/.eas/workflows/deploy_ios.yml
@@ -26,39 +26,34 @@ jobs:
       build_id: ${{ needs.build_ios.outputs.build_id }}
       profile: production
 
-  notify_slack_success:
-    name: Notify Slack (Success)
-    after: [build_ios, submit_ios]
+  notify_success:
+    name: Share iOS Production Link
+    needs: [build_ios, submit_ios]
+    if: ${{ success() }}
     environment: production
-    if: ${{ after.build_ios.status == 'finished' && after.submit_ios.status == 'finished' }}
     steps:
       - uses: eas/send_slack_message
         with:
+          slack_hook_url: ${{ env.SLACK_HOOK_URL_SUCCESS }}
           message: |
-            iOS production deploy succeeded.
-            Workflow: ${{ workflow.name }}
-            Branch: ${{ inputs.branch }}
-            Version: ${{ after.build_ios.outputs.app_version }}
-            Build status: ${{ after.build_ios.status }}
-            Submit status: ${{ after.submit_ios.status }}
-            Build URL: https://expo.dev/builds/${{ after.build_ios.outputs.build_id }}
-            Workflow URL: ${{ workflow.url }}
-          url: ${{ env.SLACK_HOOK_URL_SUCCESS }}
+            iOS production build submitted successfully.
 
-  notify_slack_failure:
-    name: Notify Slack (Failure)
+            App: ${{ needs.build_ios.outputs.app_identifier }}
+            Version: ${{ needs.build_ios.outputs.app_version }}
+            Build number: ${{ needs.build_ios.outputs.app_build_version }}
+            Build link: https://expo.dev/builds/${{ needs.build_ios.outputs.build_id }}
+
+  notify_failure:
+    name: Notify iOS Production Failure
     after: [build_ios, submit_ios]
+    if: ${{ failure() }}
     environment: production
-    if: ${{ after.build_ios.status != 'finished' || after.submit_ios.status != 'finished' }}
     steps:
       - uses: eas/send_slack_message
         with:
+          slack_hook_url: ${{ env.SLACK_HOOK_URL_FAILURE }}
           message: |
-            iOS production deploy failed.
+            iOS production build or submit failed.
+
             Workflow: ${{ workflow.name }}
-            Branch: ${{ inputs.branch }}
-            Build status: ${{ after.build_ios.status }}
-            Submit status: ${{ after.submit_ios.status }}
-            Build URL: https://expo.dev/builds/${{ after.build_ios.outputs.build_id }}
-            Workflow URL: ${{ workflow.url }}
-          url: ${{ env.SLACK_HOOK_URL_FAILURE }}
+            Details: ${{ workflow.url }}

--- a/mobile/.eas/workflows/preview_android.yml
+++ b/mobile/.eas/workflows/preview_android.yml
@@ -17,37 +17,34 @@ jobs:
       platform: android
       profile: preview
 
-  notify_slack_success:
-    name: Notify Slack (Success)
-    after: [build_android_preview]
+  notify_success:
+    name: Share Android Preview Link
+    needs: [build_android_preview]
+    if: ${{ success() }}
     environment: preview
-    if: ${{ after.build_android_preview.status == 'finished' }}
     steps:
       - uses: eas/send_slack_message
         with:
+          slack_hook_url: ${{ env.SLACK_HOOK_URL_SUCCESS }}
           message: |
-            Android preview build succeeded.
-            Workflow: ${{ workflow.name }}
-            Branch: ${{ inputs.branch }}
-            Build status: ${{ after.build_android_preview.status }}
-            App: ${{ after.build_android_preview.outputs.app_identifier }}
-            Version: ${{ after.build_android_preview.outputs.app_version }}
-            Build URL: https://expo.dev/builds/${{ after.build_android_preview.outputs.build_id }}
-            Workflow URL: ${{ workflow.url }}
-          url: ${{ env.SLACK_HOOK_URL_SUCCESS }}
+            Android preview build is ready.
 
-  notify_slack_failure:
-    name: Notify Slack (Failure)
+            App: ${{ needs.build_android_preview.outputs.app_identifier }}
+            Version: ${{ needs.build_android_preview.outputs.app_version }}
+            Build number: ${{ needs.build_android_preview.outputs.app_build_version }}
+            Build link: https://expo.dev/builds/${{ needs.build_android_preview.outputs.build_id }}
+
+  notify_failure:
+    name: Notify Android Preview Failure
     after: [build_android_preview]
+    if: ${{ failure() }}
     environment: preview
-    if: ${{ after.build_android_preview.status != 'finished' }}
     steps:
       - uses: eas/send_slack_message
         with:
+          slack_hook_url: ${{ env.SLACK_HOOK_URL_FAILURE }}
           message: |
             Android preview build failed.
+
             Workflow: ${{ workflow.name }}
-            Branch: ${{ inputs.branch }}
-            Build status: ${{ after.build_android_preview.status }}
-            Workflow URL: ${{ workflow.url }}
-          url: ${{ env.SLACK_HOOK_URL_FAILURE }}
+            Details: ${{ workflow.url }}

--- a/mobile/docs/eas-workflows/features/slack.md
+++ b/mobile/docs/eas-workflows/features/slack.md
@@ -19,7 +19,7 @@
 
 5. Confirm the app has working EAS credentials for Android Play Store and iOS App Store submissions before running production deploy workflows.
 
-The workflows use Expo's `eas/send_slack_message` action with explicit `url` set to `SLACK_HOOK_URL_SUCCESS` or `SLACK_HOOK_URL_FAILURE` depending on outcome. Neither webhook URL is committed to source control.
+The workflows use Expo's `eas/send_slack_message` action with `slack_hook_url` set to `SLACK_HOOK_URL_SUCCESS` or `SLACK_HOOK_URL_FAILURE` depending on outcome. Success jobs use `needs:` + `if: ${{ success() }}`; failure jobs use `after:` + `if: ${{ failure() }}`. Neither webhook URL is committed to source control.
 
 ## Workflows
 


### PR DESCRIPTION
## Summary

- Replace `url:` with `slack_hook_url:` on all `eas/send_slack_message` steps — the old param name caused the _"Slack webhook URL not provided"_ error
- Success notify jobs now use `needs:` + `if: ${{ success() }}` (was `after:` + status string comparison)
- Failure notify jobs now use `after:` + `if: ${{ failure() }}` (was string comparison)
- Update `docs/eas-workflows/features/slack.md` to reflect correct param and job structure

## Files changed

- `.eas/workflows/preview_android.yml`
- `.eas/workflows/deploy_android.yml`
- `.eas/workflows/deploy_ios.yml`
- `.eas/workflows/deploy.yml`
- `docs/eas-workflows/features/slack.md`

## Test plan

- [ ] Run `eas workflow:run .eas/workflows/preview_android.yml` and confirm Slack message arrives in preview channel on success
- [ ] Verify failure path triggers on a broken build

🤖 Generated with [Claude Code](https://claude.com/claude-code)