### PR TITLE
fix(kyc): default document type to ID Card on certification screen

### DIFF
--- a/mobile/app/(Views)/kyc/certification.tsx
+++ b/mobile/app/(Views)/kyc/certification.tsx
@@ -36,7 +36,7 @@ export default function KycCertification() {
   const [screenState, setScreenState] = useState<ScreenState>("loading");
   const [mtName, setMtName] = useState("");
   const [mtBirth, setMtBirth] = useState("");
-  const [docType, setDocType] = useState<DocType>("");
+  const [docType, setDocType] = useState<DocType>("id_card");
 
   const [starting, setStarting] = useState(false);
 


### PR DESCRIPTION
## Summary
- Pre-selects **ID Card** when the KYC certification screen opens
- Applies to both Android and iOS (single shared screen component)
- One-line change: `useState<DocType>("")` → `useState<DocType>("id_card")`

## Customer Request
> When the user enters the KYC verification page, they want "ID Card" to be automatically selected by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)