### PR TITLE
fix(ios): resolve fmt consteval build error from react-native-skia

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -92,7 +92,8 @@
         "expo-build-properties",
         {
           "ios": {
-            "useFrameworks": "static"
+            "useFrameworks": "static",
+            "extraPodfileConfig": "installer.pods_project.targets.each do |target|\n  target.build_configurations.each do |config|\n    config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', 'FMT_EXCEPTIONS=0']\n  end\nend"
           },
           "android": {
             "minSdkVersion": 29


### PR DESCRIPTION
## Summary
- Fixes iOS production build failure: `call to consteval function 'fmt::basic_format_string...' is not a constant expression`
- Root cause: `@shopify/react-native-skia` bundles the `{fmt}` C++ library which has a `consteval` incompatibility with Apple Clang on newer Xcode images
- Fix: inject `FMT_EXCEPTIONS=0` preprocessor definition into all pod targets via `expo-build-properties` `extraPodfileConfig`

🤖 Generated with [Claude Code](https://claude.com/claude-code)