### PR TITLE
fix(ios): disable FMT_USE_CONSTEVAL to fix Apple Clang build error

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -93,7 +93,7 @@
         {
           "ios": {
             "useFrameworks": "static",
-            "extraPodfileConfig": "installer.pods_project.targets.each do |target|\n  target.build_configurations.each do |config|\n    config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', 'FMT_EXCEPTIONS=0']\n  end\nend"
+            "extraPodfileConfig": "post_install do |installer|\n  installer.pods_project.targets.each do |target|\n    target.build_configurations.each do |config|\n      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']\n      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'FMT_USE_CONSTEVAL=0'\n    end\n  end\nend"
           },
           "android": {
             "minSdkVersion": 29


### PR DESCRIPTION
## Summary
- Previous fix (`FMT_EXCEPTIONS=0`) didn't address the root cause
- Root cause: Apple Clang doesn't fully support `consteval` even in C++20 — `@shopify/react-native-skia`'s bundled `{fmt}` library hits this via `FMT_COMPILE_STRING`
- Fix: set `FMT_USE_CONSTEVAL=0` via `GCC_PREPROCESSOR_DEFINITIONS` in a proper `post_install` Podfile block — forces `{fmt}` to use `constexpr` instead of `consteval`

🤖 Generated with [Claude Code](https://claude.com/claude-code)