### PR TITLE
fix(ios): use OTHER_CPLUSPLUSFLAGS to pass -DFMT_USE_CONSTEVAL=0

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -93,7 +93,7 @@
         {
           "ios": {
             "useFrameworks": "static",
-            "extraPodfileConfig": "post_install do |installer|\n  installer.pods_project.targets.each do |target|\n    target.build_configurations.each do |config|\n      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']\n      config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'FMT_USE_CONSTEVAL=0'\n    end\n  end\nend"
+            "extraPodfileConfig": "post_install do |installer|\n  installer.pods_project.targets.each do |target|\n    target.build_configurations.each do |config|\n      config.build_settings['OTHER_CPLUSPLUSFLAGS'] = '$(inherited) -DFMT_USE_CONSTEVAL=0'\n    end\n  end\nend"
           },
           "android": {
             "minSdkVersion": 29


### PR DESCRIPTION
## Summary
- Third attempt at fixing the Apple Clang `consteval` / `{fmt}` build error
- Root cause of previous failures: `GCC_PREPROCESSOR_DEFINITIONS` is a **string** in Xcode build settings — the Ruby `||= array` + `<<` approach mangled the value without spaces
- Fix: use `OTHER_CPLUSPLUSFLAGS = '$(inherited) -DFMT_USE_CONSTEVAL=0'` which passes the flag directly to the C++ compiler, cleanly appended to any inherited flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)