### PR TITLE
fix(ios): pin production build to macos-ventura-13.6-xcode-15.4

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -92,8 +92,7 @@
         "expo-build-properties",
         {
           "ios": {
-            "useFrameworks": "static",
-            "extraPodfileConfig": "post_install do |installer|\n  installer.pods_project.targets.each do |target|\n    target.build_configurations.each do |config|\n      config.build_settings['OTHER_CPLUSPLUSFLAGS'] = '$(inherited) -DFMT_USE_CONSTEVAL=0'\n    end\n  end\nend"
+            "useFrameworks": "static"
           },
           "android": {
             "minSdkVersion": 29

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -20,7 +20,7 @@
     "production": {
       "autoIncrement": true,
       "ios": {
-        "image": "latest"
+        "image": "macos-ventura-13.6-xcode-15.4"
       }
     }
   },


### PR DESCRIPTION
## Summary
- EAS `latest` image was updated between June 2–5 to a newer Xcode 16.x version that introduced stricter `consteval` enforcement in Apple Clang
- Two previous Podfile-based workarounds (`GCC_PREPROCESSOR_DEFINITIONS`, `OTHER_CPLUSPLUSFLAGS`) failed because expo's own `useFrameworks: static` `post_install` block runs after and overrides them
- Pins production iOS builds to `macos-ventura-13.6-xcode-15.4` (Apple Clang 15 — definitively before the consteval regression)
- Removes the non-functional `extraPodfileConfig` from `app.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)