### PR TITLE
feat(home): KYC verification badge below user ID

### DIFF
--- a/mobile/app/(Tabs)/home.tsx
+++ b/mobile/app/(Tabs)/home.tsx
@@ -247,19 +247,55 @@ export default function HomeScreen() {
           className="w-full pt-10"
         >
           <View className="pb-44 px-4">
-            <Pressable
-              onPress={() => setShowEditProfile(true)}
-              className="flex-row items-center gap-2"
-            >
-              <View className="bg-pink-1100 w-12 h-12 rounded-full items-center justify-center">
+            <View className="flex-row items-center gap-2">
+              <Pressable
+                onPress={() => setShowEditProfile(true)}
+                className="bg-pink-1100 w-12 h-12 rounded-full items-center justify-center"
+              >
                 <Text className="text-2xl font-medium text-white leading-[22px] tracking-[-0.36px]">
                   {details ? details.image : ""}
                 </Text>
+              </Pressable>
+              <View className="flex-1 items-start gap-2">
+                <Pressable
+                  onPress={() => setShowEditProfile(true)}
+                  className="max-w-full"
+                >
+                  <Text
+                    numberOfLines={1}
+                    ellipsizeMode="tail"
+                    className="text-[22px] text-white font-medium tracking-[-0.44px]"
+                  >
+                    {email}
+                  </Text>
+                </Pressable>
+                <Pressable
+                  onPress={() => router.push("/(Views)/kyc/ready")}
+                  className={`flex-row items-center gap-1.5 rounded-full border px-3 py-1 ${
+                    kycCompleted
+                      ? "bg-green-1000/15 border-green-1000/50"
+                      : "bg-red-1000/15 border-red-1000/50"
+                  }`}
+                >
+                  <View
+                    className={`w-4 h-4 rounded-full items-center justify-center ${
+                      kycCompleted ? "bg-green-1000" : "bg-red-1000"
+                    }`}
+                  >
+                    <Text className="text-[10px] font-bold text-white text-center">
+                      {kycCompleted ? "✓" : "!"}
+                    </Text>
+                  </View>
+                  <Text
+                    className={`text-[12px] font-bold tracking-[-0.2px] ${
+                      kycCompleted ? "text-green-1000" : "text-red-1000"
+                    }`}
+                  >
+                    {kycCompleted ? "KYC Verified" : "KYC Required"}
+                  </Text>
+                </Pressable>
               </View>
-              <Text className="text-[22px] text-white font-medium tracking-[-0.44px]">
-                {email}
-              </Text>
-            </Pressable>
+            </View>
 
             <View className="items-center mt-[46px] mb-10">
               {/* <SvgIcon name="spaceman" width="74" height="74" /> */}

--- a/mobile/app/(Tabs)/home.tsx
+++ b/mobile/app/(Tabs)/home.tsx
@@ -38,6 +38,7 @@ import { showLoading } from "@/src/features/loadingSlice";
 import { requestNotificationPermission } from "@/lib/notifications/requestPermissions";
 import ReceiveInstant from "../components/earn/ReceiveInstant";
 import BalanceYieldGuide from "../components/BalanceYieldGuide";
+import LabelBadge from "../components/LabelBadge";
 import useSetting from "@/hooks/api/useSetting";
 import LoanIcon from "@/assets/images/hand-dollar.svg";
 import { setSettings } from "@/src/features/settings/settingsSlice";
@@ -269,31 +270,13 @@ export default function HomeScreen() {
                     {email}
                   </Text>
                 </Pressable>
-                <Pressable
+                <LabelBadge
+                  loading={!kycFetched}
+                  tone={kycCompleted ? "success" : "danger"}
+                  glyph={kycCompleted ? "✓" : "!"}
+                  label={kycCompleted ? "KYC Verified" : "KYC Required"}
                   onPress={() => router.push("/(Views)/kyc/ready")}
-                  className={`flex-row items-center gap-1.5 rounded-full border px-3 py-1 ${
-                    kycCompleted
-                      ? "bg-green-1000/15 border-green-1000/50"
-                      : "bg-red-1000/15 border-red-1000/50"
-                  }`}
-                >
-                  <View
-                    className={`w-4 h-4 rounded-full items-center justify-center ${
-                      kycCompleted ? "bg-green-1000" : "bg-red-1000"
-                    }`}
-                  >
-                    <Text className="text-[10px] font-bold text-white text-center">
-                      {kycCompleted ? "✓" : "!"}
-                    </Text>
-                  </View>
-                  <Text
-                    className={`text-[12px] font-bold tracking-[-0.2px] ${
-                      kycCompleted ? "text-green-1000" : "text-red-1000"
-                    }`}
-                  >
-                    {kycCompleted ? "KYC Verified" : "KYC Required"}
-                  </Text>
-                </Pressable>
+                />
               </View>
             </View>
 

--- a/mobile/app/components/LabelBadge.tsx
+++ b/mobile/app/components/LabelBadge.tsx
@@ -1,0 +1,131 @@
+import React, { useEffect, useRef } from "react";
+import { Animated, Easing, Pressable, Text, View } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+
+export type LabelBadgeTone = "success" | "danger";
+
+const toneStyles: Record<
+  LabelBadgeTone,
+  { pill: string; dot: string; text: string }
+> = {
+  success: {
+    pill: "bg-green-1000/15 border-green-1000/50",
+    dot: "bg-green-1000",
+    text: "text-green-1000",
+  },
+  danger: {
+    pill: "bg-red-1000/15 border-red-1000/50",
+    dot: "bg-red-1000",
+    text: "text-red-1000",
+  },
+};
+
+/** Width/height of the skeleton shown while `loading`. */
+const SKELETON_WIDTH = 118;
+const SKELETON_HEIGHT = 26;
+
+/**
+ * Shimmer skeleton rendered in place of the badge while its data loads.
+ * Uses RN's built-in Animated (no reanimated babel plugin required) to sweep
+ * a translucent highlight across a rounded placeholder pill.
+ */
+function BadgeShimmer() {
+  const progress = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    const animation = Animated.loop(
+      Animated.timing(progress, {
+        toValue: 1,
+        duration: 1100,
+        easing: Easing.linear,
+        useNativeDriver: true,
+      })
+    );
+    animation.start();
+    return () => animation.stop();
+  }, [progress]);
+
+  const translateX = progress.interpolate({
+    inputRange: [0, 1],
+    outputRange: [-SKELETON_WIDTH, SKELETON_WIDTH],
+  });
+
+  return (
+    <View
+      accessibilityRole="progressbar"
+      accessibilityLabel="Loading status"
+      className="overflow-hidden rounded-full bg-gray-1500/40"
+      style={{ width: SKELETON_WIDTH, height: SKELETON_HEIGHT }}
+    >
+      <Animated.View
+        style={{
+          position: "absolute",
+          top: 0,
+          bottom: 0,
+          width: SKELETON_WIDTH,
+          transform: [{ translateX }],
+        }}
+      >
+        <LinearGradient
+          colors={["transparent", "rgba(255,255,255,0.18)", "transparent"]}
+          start={{ x: 0, y: 0.5 }}
+          end={{ x: 1, y: 0.5 }}
+          style={{ flex: 1 }}
+        />
+      </Animated.View>
+    </View>
+  );
+}
+
+export interface LabelBadgeProps {
+  /** Text shown inside the pill. */
+  label: string;
+  /** Short glyph rendered inside the colored circle (e.g. "✓" or "!"). */
+  glyph: string;
+  /** Colour scheme of the pill. */
+  tone: LabelBadgeTone;
+  /** When true, a shimmer skeleton is shown instead of the badge. */
+  loading?: boolean;
+  /** Optional press handler — when set the pill becomes tappable. */
+  onPress?: () => void;
+}
+
+/**
+ * A small "label with icon" status pill: a colored glyph circle followed by a
+ * label, in a rounded outlined pill. While `loading`, a shimmer skeleton is
+ * shown in its place so the real status never flashes the wrong value.
+ */
+export default function LabelBadge({
+  label,
+  glyph,
+  tone,
+  loading = false,
+  onPress,
+}: LabelBadgeProps) {
+  if (loading) {
+    return <BadgeShimmer />;
+  }
+
+  const styles = toneStyles[tone];
+  const Container = onPress ? Pressable : View;
+
+  return (
+    <Container
+      onPress={onPress}
+      accessibilityRole={onPress ? "button" : "text"}
+      accessibilityLabel={label}
+      className={`flex-row items-center gap-1.5 rounded-full border px-3 py-1 ${styles.pill}`}
+    >
+      <View
+        className={`w-4 h-4 rounded-full items-center justify-center ${styles.dot}`}
+      >
+        <Text className="text-[10px] font-bold text-white text-center">
+          {glyph}
+        </Text>
+      </View>
+      <Text className={`text-[12px] font-bold tracking-[-0.2px] ${styles.text}`}>
+        {label}
+      </Text>
+    </Container>
+  );
+}


### PR DESCRIPTION
## What
Places the **KYC verification badge directly below the user ID (email)** in the home-screen profile header, per the customer request / reference `Welcome.jsx` layout.

Before: avatar + email on a single horizontal row, no badge.
After: avatar on the left; a vertical column with the email on top and the KYC badge directly beneath it.

## Changes
- **`app/(Tabs)/home.tsx`** — restructured the profile header into avatar + vertical (email, badge) column. Email is truncated to one line so a long address can't push the badge down. The badge deep-links to the KYC flow (`/(Views)/kyc/ready`).
- **`app/components/LabelBadge.tsx`** (new) — reusable "label with icon" status pill (colored glyph circle + label, `success`/`danger` tones, optional `onPress`). While its data is loading it shows an **Animated shimmer skeleton** so the KYC status never flashes the wrong value before the fetch settles.

## Badge states
- `kycCompleted` → green `✓ KYC Verified`
- otherwise → red `! KYC Required`
- loading (`!kycFetched`) → shimmer skeleton

## Verification
- `tsc --noEmit`: the new component compiles clean; these edits add **zero** new type errors (remaining repo errors are pre-existing on `main`).
- Two review passes (diff + component) — no defects; shimmer uses RN's built-in `Animated` (native-driver `translateX`, cleaned up on unmount), no reanimated babel plugin required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)