### PR TITLE
ci: trigger EAS Workflows from GitHub Actions

### DIFF
--- a/.github/workflows/eas.yml
+++ b/.github/workflows/eas.yml
@@ -45,7 +45,7 @@ jobs:
         uses: expo/expo-github-action@v8
         with:
           eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
+          token: ${{ secrets.EXPO_ACCESS_TOKEN }}
 
       # Production deploy on merge to main.
       - name: Deploy (push to main)

--- a/.github/workflows/eas.yml
+++ b/.github/workflows/eas.yml
@@ -6,7 +6,8 @@ name: EAS
 
 on:
   push:
-    branches: [main]
+    tags:
+      - "v*" # production deploy on a new version tag, e.g. v1.2.3
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -47,9 +48,9 @@ jobs:
           eas-version: latest
           token: ${{ secrets.EXPO_ACCESS_TOKEN }}
 
-      # Production deploy on merge to main.
-      - name: Deploy (push to main)
-        if: github.event_name == 'push'
+      # Production deploy when a new version tag (v*) is pushed.
+      - name: Deploy (new tag)
+        if: startsWith(github.ref, 'refs/tags/v')
         run: eas workflow:run deploy.yml
 
       # Preview build for PRs, so reviewers get an installable Android build.

--- a/.github/workflows/eas.yml
+++ b/.github/workflows/eas.yml
@@ -1,0 +1,63 @@
+name: EAS
+
+# Triggers the EAS Workflows defined in mobile/.eas/workflows/*.yml.
+# The actual build/submit runs on Expo's servers — this job just authenticates
+# with EXPO_TOKEN and kicks off the chosen EAS workflow.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      workflow:
+        description: EAS workflow file to run (from mobile/.eas/workflows)
+        type: choice
+        default: deploy.yml
+        options:
+          - deploy.yml
+          - deploy_ios.yml
+          - deploy_android.yml
+          - preview_android.yml
+          - create-production-builds.yml
+
+concurrency:
+  group: eas-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  trigger-eas:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mobile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      # Production deploy on merge to main.
+      - name: Deploy (push to main)
+        if: github.event_name == 'push'
+        run: eas workflow:run deploy.yml
+
+      # Preview build for PRs, so reviewers get an installable Android build.
+      - name: Preview (pull request)
+        if: github.event_name == 'pull_request'
+        run: eas workflow:run preview_android.yml
+
+      # Manual run — pick any workflow from the dropdown.
+      - name: Manual dispatch
+        if: github.event_name == 'workflow_dispatch'
+        run: eas workflow:run ${{ inputs.workflow }}


### PR DESCRIPTION
Adds .github/workflows/eas.yml to trigger the EAS Workflows in mobile/.eas/workflows (push to main -> deploy.yml, PR -> preview_android.yml, manual dispatch -> dropdown). Requires repo secret EXPO_TOKEN. Job runs with working-directory: mobile.