### PR TITLE
feat(withdrawal): gate KYC check on $1,000 threshold

### DIFF
--- a/mobile/app/(Views)/withdrawal-view.tsx
+++ b/mobile/app/(Views)/withdrawal-view.tsx
@@ -39,6 +39,8 @@ import {
   setLockupBalances,
 } from "@/src/features/balance/balanceSlice";
 
+const KYC_REQUIRED_THRESHOLD = 1000;
+
 const WithDrawal = () => {
   const navigation = useNavigation();
   const kycCompleted = useSelector((state: RS) => state.user.kycCompleted);
@@ -161,6 +163,11 @@ const WithDrawal = () => {
       return;
     }
 
+    if (amount.greaterThanOrEqualTo(KYC_REQUIRED_THRESHOLD) && !kycCompleted) {
+      router.replace("/(Views)/kyc/ready");
+      return;
+    }
+
     router.push({
       pathname: "/confirm-withdrawl",
       params: {
@@ -181,15 +188,11 @@ const WithDrawal = () => {
     try {
       const res = await useKyc.getKycInfo();
       if (typeof res !== "string") {
-        const done = res.kyc_yn === "Y";
-        dispatch(setKycCompleted(done));
+        dispatch(setKycCompleted(res.kyc_yn === "Y"));
         dispatch(setKycFetched(true));
-        if (!done) {
-          router.replace("/(Views)/kyc/ready");
-        }
       }
     } catch {
-      // silent — do not block withdrawal if KYC check fails
+      // silent — do not block page load if KYC check fails
     }
   };
 
@@ -303,6 +306,12 @@ const WithDrawal = () => {
                     ))}
                   </View>
                 </View>
+              </View>
+
+              <View className="mx-1 mb-3 px-4 py-3 rounded-[12px] bg-yellow-500/10 border border-yellow-500/30">
+                <Text className="text-yellow-400 text-sm text-center">
+                  {t("withdrawal.kyc_required_above")}
+                </Text>
               </View>
 
               <PrimaryButton text={t("withdrawal.next")} onPress={handleNext} />

--- a/mobile/locales/en/translation.json
+++ b/mobile/locales/en/translation.json
@@ -245,6 +245,7 @@
     "invalid_address": "Please enter a valid withdrawal address.",
     "invalid_amount": "Please enter a valid withdrawal amount.",
     "insufficient_balance": "Insufficient balance. Available: {{balance}} {{symbol}}",
+    "kyc_required_above": "Withdrawals of $1,000 or more require KYC verification.",
     "next": "NEXT"
   },
   "lockup": {

--- a/mobile/locales/ko/translation.json
+++ b/mobile/locales/ko/translation.json
@@ -230,6 +230,7 @@
     "invalid_address": "유효한 출금 주소를 입력해주세요.",
     "invalid_amount": "유효한 출금 금액을 입력해주세요.",
     "insufficient_balance": "잔액 부족. 사용 가능: {{balance}} {{symbol}}",
+    "kyc_required_above": "$1,000 이상 출금 시 KYC 인증이 필요합니다.",
     "next": "다음"
   },
   "lockup": {


### PR DESCRIPTION
## Summary

- KYC verification is now only required when withdrawal amount is **≥ $1,000** (hardcoded, to be made server-driven later)
- Previously, KYC was enforced on every withdrawal regardless of amount — this blocked small withdrawals unnecessarily
- A visible amber warning banner is shown on the withdrawal page: _"Withdrawals of $1,000 or more require KYC verification."_

## Changes

- `app/(Views)/withdrawal-view.tsx` — added `KYC_REQUIRED_THRESHOLD = 1000`; removed blanket KYC redirect on page mount; added threshold check in `handleNext`; added warning banner above NEXT button
- `locales/en/translation.json` + `locales/ko/translation.json` — added `withdrawal.kyc_required_above` key (EN + KO)

## Test plan

- [ ] Withdrawal < $1,000 with KYC not completed → proceeds to confirm screen normally
- [ ] Withdrawal ≥ $1,000 with KYC not completed → redirects to KYC ready screen
- [ ] Withdrawal ≥ $1,000 with KYC completed → proceeds to confirm screen normally
- [ ] Warning banner visible on withdrawal page for all users
- [ ] Korean locale shows the translated warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)