### PR TITLE
chore(workflows): add push triggers on preview and release branches

### DIFF
--- a/mobile/.eas/workflows/deploy.yml
+++ b/mobile/.eas/workflows/deploy.yml
@@ -2,6 +2,11 @@ name: Deploy
 
 "on":
   workflow_dispatch: {}
+  push:
+    branches:
+      - release
+    paths:
+      - mobile/**
 
 jobs:
   build_android:

--- a/mobile/.eas/workflows/deploy_android.yml
+++ b/mobile/.eas/workflows/deploy_android.yml
@@ -1,12 +1,12 @@
 name: Deploy Android
 
-on:
-  workflow_dispatch:
-    inputs:
-      branch:
-        type: string
-        description: Branch to build from
-        default: master
+"on":
+  workflow_dispatch: {}
+  push:
+    branches:
+      - release
+    paths:
+      - mobile/**
 
 jobs:
   build_android:

--- a/mobile/.eas/workflows/deploy_ios.yml
+++ b/mobile/.eas/workflows/deploy_ios.yml
@@ -1,12 +1,12 @@
 name: Deploy iOS
 
-on:
-  workflow_dispatch:
-    inputs:
-      branch:
-        type: string
-        description: Branch to build from
-        default: master
+"on":
+  workflow_dispatch: {}
+  push:
+    branches:
+      - release
+    paths:
+      - mobile/**
 
 jobs:
   build_ios:

--- a/mobile/.eas/workflows/preview_android.yml
+++ b/mobile/.eas/workflows/preview_android.yml
@@ -1,12 +1,12 @@
 name: Android Preview Build
 
-on:
-  workflow_dispatch:
-    inputs:
-      branch:
-        type: string
-        description: Branch to build from
-        default: master
+"on":
+  workflow_dispatch: {}
+  push:
+    branches:
+      - preview
+    paths:
+      - mobile/**
 
 jobs:
   build_android_preview:


### PR DESCRIPTION
## Summary

- `preview_android.yml` — auto-triggers on push to `preview` branch when `mobile/**` changes
- `deploy.yml`, `deploy_android.yml`, `deploy_ios.yml` — auto-trigger on push to `release` branch when `mobile/**` changes
- All four workflows retain `workflow_dispatch` for manual runs
- Removed the stale `branch` input (push events supply branch context automatically)

## Branches created

- `preview` — branch to push to for preview builds (tracks main at this PR's merge point)
- `release` — branch to push to for production deploys (tracks main at this PR's merge point)

## Test plan

- [ ] Push a change to `mobile/**` on `preview` branch → `preview_android` workflow triggers automatically
- [ ] Push a change to `mobile/**` on `release` branch → `deploy`, `deploy_android`, `deploy_ios` workflows trigger automatically
- [ ] Manual `workflow_dispatch` still works for all four workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)