### PR TITLE
chore(app): bump version to 1.0.45

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Ping Wallet",
     "slug": "mecca",
-    "version": "1.0.44",
+    "version": "1.0.45",
     "orientation": "portrait",
     "icon": "./assets/images/app_icon.png",
     "scheme": [


### PR DESCRIPTION
## Summary

Patch version bump: `1.0.44` → `1.0.45`

- `mobile/app.json` — `version` updated for both Android and iOS builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)