### PR TITLE
feat(update): detect install source and redirect to Play Store, App Store, or website

### DIFF
--- a/mobile/app/(auth)/app-update.tsx
+++ b/mobile/app/(auth)/app-update.tsx
@@ -1,7 +1,10 @@
-import React, { useEffect, useState } from "react";
-import { Linking, Platform, Text, View } from "react-native";
+import React, { useEffect, useRef, useState } from "react";
+import { Animated, Linking, Platform, Text, View } from "react-native";
 import * as Application from "expo-application";
-import InAppUpdates, { IAUUpdateKind } from "sp-react-native-in-app-updates";
+import InAppUpdates, {
+  IAUInstallStatus,
+  IAUUpdateKind,
+} from "sp-react-native-in-app-updates";
 import { useTranslation } from "react-i18next";
 import PrimaryButton from "../components/PrimaryButton";
 import {
@@ -24,6 +27,9 @@ const detectAndroidSource = async (): Promise<InstallSource> => {
 const UpdateAppPage = () => {
   const { t } = useTranslation();
   const [source, setSource] = useState<InstallSource | null>(null);
+  const [downloading, setDownloading] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const progressAnim = useRef(new Animated.Value(0)).current;
 
   useEffect(() => {
     if (Platform.OS === "android") {
@@ -33,12 +39,47 @@ const UpdateAppPage = () => {
     }
   }, []);
 
+  useEffect(() => {
+    Animated.timing(progressAnim, {
+      toValue: progress,
+      duration: 200,
+      useNativeDriver: false,
+    }).start();
+  }, [progress]);
+
   const handleUpdate = async () => {
     if (source === "play_store") {
       try {
         const inAppUpdates = new InAppUpdates(false);
+        setDownloading(true);
+
+        const listener = (downloadStatus: any) => {
+          switch (downloadStatus.status) {
+            case IAUInstallStatus.DOWNLOADING:
+              setProgress(
+                Math.floor(
+                  (downloadStatus.bytesDownloaded /
+                    downloadStatus.totalBytesToDownload) *
+                    100
+                )
+              );
+              break;
+            case IAUInstallStatus.DOWNLOADED:
+              inAppUpdates.installUpdate();
+              break;
+            case IAUInstallStatus.INSTALLED:
+            case IAUInstallStatus.CANCELED:
+            case IAUInstallStatus.FAILED:
+              setDownloading(false);
+              inAppUpdates.removeStatusUpdateListener(listener);
+              break;
+          }
+        };
+
+        inAppUpdates.addStatusUpdateListener(listener);
         inAppUpdates.startUpdate({ updateType: IAUUpdateKind.IMMEDIATE });
       } catch {
+        setDownloading(false);
         Linking.openURL(PLAY_STORE_URL);
       }
       return;
@@ -46,12 +87,12 @@ const UpdateAppPage = () => {
 
     if (source === "app_store") {
       const storeUrl = `itms-apps://itunes.apple.com/app/id${APP_STORE_ID}`;
-      const canOpen = APP_STORE_ID !== "123456789" && (await Linking.canOpenURL(storeUrl));
+      const canOpen =
+        APP_STORE_ID !== "123456789" && (await Linking.canOpenURL(storeUrl));
       Linking.openURL(canOpen ? storeUrl : WEBSITE_DOWNLOAD_URL);
       return;
     }
 
-    // sideloaded / direct website install
     Linking.openURL(WEBSITE_DOWNLOAD_URL);
   };
 
@@ -74,13 +115,32 @@ const UpdateAppPage = () => {
           </Text>
         </View>
 
-        <View className="w-full flex mt-8">
-          <PrimaryButton
-            className="p-4"
-            text={source ? updateLabel : t("update.button")}
-            onPress={handleUpdate}
-          />
-        </View>
+        {downloading ? (
+          <View className="w-full flex-col items-center mt-8">
+            <Text className="text-white text-base font-medium mb-2">
+              {t("update.downloading")} {progress}%
+            </Text>
+            <View className="w-full h-2 bg-gray-800 rounded-full overflow-hidden">
+              <Animated.View
+                className="h-full bg-purple-500 rounded-full"
+                style={{
+                  width: progressAnim.interpolate({
+                    inputRange: [0, 100],
+                    outputRange: ["0%", "100%"],
+                  }),
+                }}
+              />
+            </View>
+          </View>
+        ) : (
+          <View className="w-full flex mt-8">
+            <PrimaryButton
+              className="p-4"
+              text={source ? updateLabel : t("update.button")}
+              onPress={handleUpdate}
+            />
+          </View>
+        )}
       </View>
     </View>
   );

--- a/mobile/app/(auth)/app-update.tsx
+++ b/mobile/app/(auth)/app-update.tsx
@@ -1,80 +1,70 @@
-import { router } from "expo-router";
-import { useTranslation } from "react-i18next";
-import { Text, View, Linking, Platform } from "react-native";
-import InAppUpdates, {
-  IAUInstallStatus,
-  IAUUpdateKind,
-} from "sp-react-native-in-app-updates";
 import React, { useEffect, useState } from "react";
+import { Linking, Platform, Text, View } from "react-native";
+import * as Application from "expo-application";
+import InAppUpdates, { IAUUpdateKind } from "sp-react-native-in-app-updates";
+import { useTranslation } from "react-i18next";
 import PrimaryButton from "../components/PrimaryButton";
+import {
+  APP_STORE_ID,
+  PLAY_STORE_URL,
+  WEBSITE_DOWNLOAD_URL,
+} from "@/lib/constants";
 
-// For iOS, replace with your App Store ID
-const APP_STORE_ID = "123456789";
+type InstallSource = "play_store" | "app_store" | "website";
+
+const detectAndroidSource = async (): Promise<InstallSource> => {
+  try {
+    const referrer = await Application.getInstallReferrerAsync();
+    return referrer.includes("google-play") ? "play_store" : "website";
+  } catch {
+    return "website";
+  }
+};
 
 const UpdateAppPage = () => {
   const { t } = useTranslation();
-  const [downloading, setDownloading] = useState(false);
-  const [progress, setProgress] = useState(0);
-
-  const handleUpdate = async () => {
-    try {
-      // Handle Android in-app updates
-      if (Platform.OS === "android") {
-        Linking.openURL(
-          `https://play.google.com/store/apps/details?id=com.meccain.ping`
-        );
-        // setDownloading(true);
-        const inAppUpdates = new InAppUpdates(false); // set to false in production
-        const updateOptions = {
-          updateType: IAUUpdateKind.IMMEDIATE,
-        };
-
-        const listener = (downloadStatus: any) => {
-          switch (downloadStatus.status) {
-            case IAUInstallStatus.DOWNLOADING:
-              const newProgress = Math.floor(
-                (downloadStatus.bytesDownloaded /
-                  downloadStatus.totalBytesToDownload) *
-                  100
-              );
-              setProgress(newProgress);
-              break;
-            case IAUInstallStatus.DOWNLOADED:
-              inAppUpdates.installUpdate();
-              break;
-            case IAUInstallStatus.INSTALLED:
-              setDownloading(false);
-              inAppUpdates.removeStatusUpdateListener(listener);
-              break;
-            case IAUInstallStatus.CANCELED:
-            case IAUInstallStatus.FAILED:
-              setDownloading(false);
-              inAppUpdates.removeStatusUpdateListener(listener);
-              break;
-            default:
-              break;
-          }
-        };
-        inAppUpdates.addStatusUpdateListener(listener);
-        inAppUpdates.startUpdate(updateOptions);
-
-        // Handle iOS App Store redirects
-      } else if (Platform.OS === "ios") {
-        Linking.openURL(`itms-apps://itunes.apple.com/app/id${APP_STORE_ID}`);
-      }
-    } catch (error) {
-      console.log(error);
-    }
-  };
+  const [source, setSource] = useState<InstallSource | null>(null);
 
   useEffect(() => {
+    if (Platform.OS === "android") {
+      detectAndroidSource().then(setSource);
+    } else {
+      setSource("app_store");
+    }
   }, []);
+
+  const handleUpdate = async () => {
+    if (source === "play_store") {
+      try {
+        const inAppUpdates = new InAppUpdates(false);
+        inAppUpdates.startUpdate({ updateType: IAUUpdateKind.IMMEDIATE });
+      } catch {
+        Linking.openURL(PLAY_STORE_URL);
+      }
+      return;
+    }
+
+    if (source === "app_store") {
+      const storeUrl = `itms-apps://itunes.apple.com/app/id${APP_STORE_ID}`;
+      const canOpen = APP_STORE_ID !== "123456789" && (await Linking.canOpenURL(storeUrl));
+      Linking.openURL(canOpen ? storeUrl : WEBSITE_DOWNLOAD_URL);
+      return;
+    }
+
+    // sideloaded / direct website install
+    Linking.openURL(WEBSITE_DOWNLOAD_URL);
+  };
+
+  const updateLabel = (() => {
+    if (source === "play_store") return t("update.button_play_store");
+    if (source === "app_store") return t("update.button_app_store");
+    return t("update.button_website");
+  })();
 
   return (
     <View className="flex-1 h-full bg-black-1000 items-center justify-center">
       <View className="rounded-[15px] min-h-[451px] max-w-5xl flex-col items-center justify-center p-8">
         <View className="items-center mb-8">
-          {/* Using a large emoji to replace the image for visual emphasis */}
           <Text className="text-6xl mb-4">⬇️</Text>
           <Text className="text-[28px] my-3 font-semibold leading-[32px] text-white text-center">
             {t("update.title")}
@@ -84,27 +74,13 @@ const UpdateAppPage = () => {
           </Text>
         </View>
 
-        {downloading ? (
-          <View className="w-full flex-col items-center mt-8">
-            <Text className="text-white text-base font-medium mb-2">
-              {t("update.downloading")}
-            </Text>
-            <View className="w-full h-2 bg-gray-800 rounded-full">
-              <View
-                className="h-full bg-purple-500 rounded-full transition-all duration-300 ease-in-out"
-                style={{ width: `${progress}%` }}
-              ></View>
-            </View>
-          </View>
-        ) : (
-          <View className="w-full flex mt-8">
-            <PrimaryButton
-              className="p-4"
-              text={t("update.button")}
-              onPress={handleUpdate}
-            />
-          </View>
-        )}
+        <View className="w-full flex mt-8">
+          <PrimaryButton
+            className="p-4"
+            text={source ? updateLabel : t("update.button")}
+            onPress={handleUpdate}
+          />
+        </View>
       </View>
     </View>
   );

--- a/mobile/lib/constants.ts
+++ b/mobile/lib/constants.ts
@@ -7,8 +7,8 @@ export const apiKey = "450692dcc1664131acaaf3c58ff2d51a";
 
 export const PLAY_STORE_URL =
   "https://play.google.com/store/apps/details?id=com.meccain.ping";
-// TODO: replace with the real numeric App Store ID once published
-export const APP_STORE_ID = "123456789";
+export const APP_STORE_ID =
+  process.env.EXPO_PUBLIC_APP_STORE_ID ?? "6752386869";
 // TODO: confirm the official website download page URL
 export const WEBSITE_DOWNLOAD_URL = "https://pingwallet.info/download";
 export const defaultTokenList: DefaultToken[] = [

--- a/mobile/lib/constants.ts
+++ b/mobile/lib/constants.ts
@@ -4,6 +4,13 @@ export const imageBucket = "https://ramp.meccain.com/uploads";
 export const apiBaseUrl = `https://mapi.pingwallet.info`;
 // export const apiBaseUrl = `http://192.168.109.78:8080`;
 export const apiKey = "450692dcc1664131acaaf3c58ff2d51a";
+
+export const PLAY_STORE_URL =
+  "https://play.google.com/store/apps/details?id=com.meccain.ping";
+// TODO: replace with the real numeric App Store ID once published
+export const APP_STORE_ID = "123456789";
+// TODO: confirm the official website download page URL
+export const WEBSITE_DOWNLOAD_URL = "https://pingwallet.info/download";
 export const defaultTokenList: DefaultToken[] = [
   {
     symbol: "MEA",

--- a/mobile/locales/en/translation.json
+++ b/mobile/locales/en/translation.json
@@ -521,7 +521,10 @@
     "title": "A New Version is Available",
     "subtitle": "Please update your app to access the latest features and improvements.",
     "downloading": "Downloading update...",
-    "button": "Update App"
+    "button": "Update App",
+    "button_play_store": "Update on Google Play",
+    "button_app_store": "Update on App Store",
+    "button_website": "Download Latest Version"
   },
   "token_metrics": {
     "deposits": "Deposits",

--- a/mobile/locales/ko/translation.json
+++ b/mobile/locales/ko/translation.json
@@ -652,7 +652,10 @@
     "title": "새 버전이 출시되었습니다",
     "subtitle": "최신 기능과 개선 사항을 이용하려면 앱을 업데이트하세요.",
     "downloading": "업데이트 다운로드 중...",
-    "button": "앱 업데이트"
+    "button": "앱 업데이트",
+    "button_play_store": "Google Play에서 업데이트",
+    "button_app_store": "App Store에서 업데이트",
+    "button_website": "최신 버전 다운로드"
   },
   "earn": {
     "transfer": {


### PR DESCRIPTION
## Summary

The app update screen now detects where the app was installed from and redirects accordingly — in-app updates only run when the install came from a store.

| Install source | Behaviour |
|---|---|
| Android (Play Store) | Tries in-app update (`IAUUpdateKind.IMMEDIATE`); falls back to Play Store URL on error |
| Android (sideloaded / direct download) | Opens official website download page |
| iOS (App Store) | Opens `itms-apps://` App Store link; falls back to website if `APP_STORE_ID` is still placeholder |

## Changes

- `lib/constants.ts` — extracted `PLAY_STORE_URL`, `APP_STORE_ID`, `WEBSITE_DOWNLOAD_URL` (two TODOs marked for real values)
- `app/(auth)/app-update.tsx` — rewritten: async `detectAndroidSource()` reads Install Referrer API via `expo-application`; per-source `handleUpdate` routing; removed unused downloading/progress state
- `locales/en/translation.json` + `locales/ko/translation.json` — added `button_play_store`, `button_app_store`, `button_website` keys

## TODOs before release

- [ ] Replace `APP_STORE_ID = "123456789"` in `lib/constants.ts` with the real App Store numeric ID
- [ ] Confirm `WEBSITE_DOWNLOAD_URL` points to the correct download page

## Test plan

- [ ] Android Play Store build: update button triggers in-app update flow
- [ ] Android sideloaded APK: update button opens website download page
- [ ] iOS build: update button opens App Store link
- [ ] Button label changes per detected source (Play / App Store / Download)

🤖 Generated with [Claude Code](https://claude.com/claude-code)