### PR TITLE
fix(new-arch): New Architecture compatibility — Portal→Modal, opacityAnim race fix, v1.1.0

### DIFF
--- a/mobile/app/(Views)/chart-view.tsx
+++ b/mobile/app/(Views)/chart-view.tsx
@@ -261,7 +261,7 @@ const ActionButton = ({
   onPress: () => void;
 }) => (
   <Pressable onPress={onPress}>
-    <View className="bg-black-1300 rounded-2xl items-center p-[18px] py-[17px] flex-1 w-28">
+    <View className="bg-black-1300 rounded-2xl items-center p-[18px] py-[17px] w-28">
       {/** @ts-ignore */}
       <SvgIcon name={icon} width="24" height="24" />
       <Text className="text-[13px] font-semibold mt-1 text-gray-1000">

--- a/mobile/app/(Views)/confirm-withdrawl.tsx
+++ b/mobile/app/(Views)/confirm-withdrawl.tsx
@@ -218,26 +218,25 @@ const ConfirmWithdraw = () => {
               </View>
             </View>
           </View>
-
-          <InfoAlert
-            {...infoAlertState}
-            visible={infoAlertVisible}
-            setVisible={setInfoAlertVisible}
-            onDismiss={() => {
-              if (withdrawlSuccess) {
-                if (router.canDismiss()) {
-                  router.dismissAll();
-                }
-                router.replace({
-                  pathname: "/(Views)/asset-history",
-                  params: {
-                    symbol: symbol,
-                  },
-                });
-              }
-            }}
-          />
         </ScrollView>
+        <InfoAlert
+          {...infoAlertState}
+          visible={infoAlertVisible}
+          setVisible={setInfoAlertVisible}
+          onDismiss={() => {
+            if (withdrawlSuccess) {
+              if (router.canDismiss()) {
+                router.dismissAll();
+              }
+              router.replace({
+                pathname: "/(Views)/asset-history",
+                params: {
+                  symbol: symbol,
+                },
+              });
+            }
+          }}
+        />
       </KeyboardAvoidingView>
     </View>
   );

--- a/mobile/app/(Views)/deposit-view.tsx
+++ b/mobile/app/(Views)/deposit-view.tsx
@@ -68,11 +68,14 @@ const Deposit = () => {
   };
 
   const handleNext = () => {
-    if (!depositAmount || parseFloat(depositAmount) < parseFloat(minDeposit)) {
+    const parsed = parseFloat(depositAmount);
+    const min = parseFloat(minDeposit);
+
+    if (!depositAmount || isNaN(parsed) || isNaN(min) || parsed < min) {
       setInfoAlertState({
         type: "error",
         text: t("deposit.min_deposit_error", {
-          amount: minDeposit,
+          amount: minDeposit ?? "—",
           symbol: displaySymbol,
         }),
       });
@@ -162,14 +165,14 @@ const Deposit = () => {
             </View>
           </View>
 
-          <InfoAlert
-            {...infoAlertState}
-            visible={infoAlertVisible}
-            setVisible={setInfoAlertVisible}
-            onDismiss={() => {}}
-          />
         </ScrollView>
       </KeyboardAvoidingView>
+      <InfoAlert
+        {...infoAlertState}
+        visible={infoAlertVisible}
+        setVisible={setInfoAlertVisible}
+        onDismiss={() => {}}
+      />
     </View>
   );
 };

--- a/mobile/app/(Views)/earn/transfer/confirm-transfer.tsx
+++ b/mobile/app/(Views)/earn/transfer/confirm-transfer.tsx
@@ -171,26 +171,25 @@ const ConfirmTransfer = () => {
               </View>
             </View>
           </View>
-
-          <InfoAlert
-            {...infoAlertState}
-            visible={infoAlertVisible}
-            setVisible={setInfoAlertVisible}
-            onDismiss={() => {
-              if (transferSuccess) {
-                if (router.canDismiss()) {
-                  router.dismissAll();
-                }
-                router.replace({
-                  pathname: "/(Views)/asset-history",
-                  params: {
-                    symbol: symbol,
-                  },
-                });
-              }
-            }}
-          />
         </ScrollView>
+        <InfoAlert
+          {...infoAlertState}
+          visible={infoAlertVisible}
+          setVisible={setInfoAlertVisible}
+          onDismiss={() => {
+            if (transferSuccess) {
+              if (router.canDismiss()) {
+                router.dismissAll();
+              }
+              router.replace({
+                pathname: "/(Views)/asset-history",
+                params: {
+                  symbol: symbol,
+                },
+              });
+            }
+          }}
+        />
       </KeyboardAvoidingView>
     </View>
   );

--- a/mobile/app/(Views)/earn/transfer/initiate-transfer.tsx
+++ b/mobile/app/(Views)/earn/transfer/initiate-transfer.tsx
@@ -182,14 +182,13 @@ const InitiateTransfer = () => {
               </View>
             </View>
           </View>
-
-          <InfoAlert
-            {...infoAlertState}
-            visible={infoAlertVisible}
-            setVisible={setInfoAlertVisible}
-            onDismiss={() => {}}
-          />
         </ScrollView>
+        <InfoAlert
+          {...infoAlertState}
+          visible={infoAlertVisible}
+          setVisible={setInfoAlertVisible}
+          onDismiss={() => {}}
+        />
       </KeyboardAvoidingView>
     </View>
   );

--- a/mobile/app/(Views)/kyc/ready.tsx
+++ b/mobile/app/(Views)/kyc/ready.tsx
@@ -11,10 +11,10 @@ import {
   View,
 } from "react-native";
 import * as WebBrowser from "expo-web-browser";
-import Toast from "react-native-toast-message";
 import { useDispatch } from "react-redux";
 import { AppDispatch } from "@/src/store";
 import { setKycCompleted } from "@/src/features/user/userSlice";
+import { showInfo } from "@/src/features/infoOverLaySlice";
 import { BackButton } from "../../components/BackButton";
 import PrimaryButton from "../../components/PrimaryButton";
 import LabeledInput from "../../components/LabeledInput";
@@ -92,7 +92,7 @@ export default function KycReady() {
       server_error: "Server error. Please try again.",
     };
 
-    Toast.show({ type: "error", text1: msgs[status] ?? "Verification failed. Please try again." });
+    dispatch(showInfo({ type: "error", message: msgs[status] ?? "Verification failed. Please try again." }));
     setScreenState("form");
   };
 
@@ -111,7 +111,7 @@ export default function KycReady() {
         if (typeof res === "string") {
           stopPolling();
           await clearSession();
-          Toast.show({ type: "error", text1: "Verification error. Please try again." });
+          dispatch(showInfo({ type: "error", message: "Verification error. Please try again." }));
           setScreenState("form");
           return;
         }
@@ -169,15 +169,15 @@ export default function KycReady() {
 
   const handleSubmit = async () => {
     if (!name.trim()) {
-      Toast.show({ type: "error", text1: "Please enter your full name." });
+      dispatch(showInfo({ type: "error", message: "Please enter your full name." }));
       return;
     }
     if (!birth.trim()) {
-      Toast.show({ type: "error", text1: "Please enter your date of birth." });
+      dispatch(showInfo({ type: "error", message: "Please enter your date of birth." }));
       return;
     }
     if (!isValidBirth(birth.trim())) {
-      Toast.show({ type: "error", text1: "Date of birth must be YYYY-MM-DD format." });
+      dispatch(showInfo({ type: "error", message: "Date of birth must be YYYY-MM-DD format." }));
       return;
     }
 
@@ -189,7 +189,7 @@ export default function KycReady() {
           router.push("/(Views)/kyc/certification");
           return;
         }
-        Toast.show({ type: "error", text1: res || "Failed to save." });
+        dispatch(showInfo({ type: "error", message: res || "Failed to save." }));
         return;
       }
       if (res.status === "already_kyc_verified") {
@@ -198,7 +198,7 @@ export default function KycReady() {
       }
       router.push("/(Views)/kyc/certification");
     } catch {
-      Toast.show({ type: "error", text1: "An error occurred. Please try again." });
+      dispatch(showInfo({ type: "error", message: "An error occurred. Please try again." }));
     } finally {
       setSaving(false);
     }

--- a/mobile/app/(Views)/settings/change-password.tsx
+++ b/mobile/app/(Views)/settings/change-password.tsx
@@ -217,18 +217,18 @@ const ChangePassword: React.FC = () => {
             </View>
           </View>
 
-          <InfoAlert
-            {...modalState}
-            visible={popUpVisible}
-            setVisible={setPopUpVisible}
-            onDismiss={() => {
-              if (passwordUpdated) {
-                router.back();
-              }
-            }}
-          />
-          <OtpModal visible={otpModalVisible} onClose={handleOTPSubmit} />
         </ScrollView>
+        <InfoAlert
+          {...modalState}
+          visible={popUpVisible}
+          setVisible={setPopUpVisible}
+          onDismiss={() => {
+            if (passwordUpdated) {
+              router.back();
+            }
+          }}
+        />
+        <OtpModal visible={otpModalVisible} onClose={handleOTPSubmit} />
       </KeyboardAvoidingView>
     </View>
   );

--- a/mobile/app/(Views)/settings/change-password.tsx
+++ b/mobile/app/(Views)/settings/change-password.tsx
@@ -1,4 +1,5 @@
 import InfoAlert, { InfoAlertProps } from "@/app/components/InfoAlert";
+import PrimaryButton from "@/app/components/PrimaryButton";
 import SvgIcon from "@/app/components/SvgIcon";
 import LabelInput from "@/app/components/LabeledInput";
 import { router, useNavigation } from "expo-router";
@@ -204,16 +205,11 @@ const ChangePassword: React.FC = () => {
             </View>
 
             {/* Bottom Button */}
-            <View className="items-center mt-6">
-              <TouchableOpacity
-                activeOpacity={0.7}
+            <View className="mt-6">
+              <PrimaryButton
+                text={t("common.ok")}
                 onPress={handleChangePassword}
-                className="mb-[9px]"
-              >
-                <Text className="text-base text-white font-semibold">
-                  {t("common.ok")}
-                </Text>
-              </TouchableOpacity>
+              />
             </View>
           </View>
 

--- a/mobile/app/(Views)/settings/google-otp.tsx
+++ b/mobile/app/(Views)/settings/google-otp.tsx
@@ -1,6 +1,6 @@
 import InfoAlert, { InfoAlertProps } from "@/app/components/InfoAlert";
 import useUser from "@/hooks/api/useUser";
-import QRCodeStyled from "react-native-qrcode-styled";
+import QRCode from "react-native-qrcode-svg";
 import { setTwoFAData } from "@/src/features/user/userSlice";
 import { RootState } from "@/src/store";
 import { useAppDispatch } from "@/src/store/hooks";
@@ -128,7 +128,7 @@ const GoogleOTP = () => {
             <View className="w-full">
               {/* QR Code */}
               <View className="items-center">
-                {twoFAData ? (
+                {twoFAData && twoFAData.qrUrl ? (
                   twoFAData.qrUrl.startsWith("http") ? (
                     <Image
                       source={{ uri: twoFAData.qrUrl }}
@@ -136,18 +136,13 @@ const GoogleOTP = () => {
                       resizeMode="contain"
                     />
                   ) : (
-                    <QRCodeStyled
-                      data={twoFAData.qrUrl}
-                      style={{ backgroundColor: "white" }}
-                      padding={20}
+                    <QRCode
+                      value={twoFAData.qrUrl}
+                      size={200}
+                      backgroundColor="white"
                     />
                   )
-                ) : (
-                  <View className="w-[200px] h-[200px] border-2 border-gray-400 rounded-md justify-center items-center">
-                    {/* Optional placeholder text or icon */}
-                    <Text className="text-gray-400">QR Code</Text>
-                  </View>
-                )}
+                ) : null}
               </View>
 
               {/* Input with Copy Button */}
@@ -224,17 +219,17 @@ const GoogleOTP = () => {
             </View>
           </View>
         </View>
-        <InfoAlert
-          {...modalState}
-          visible={modalVisible}
-          setVisible={setModalVisible}
-          onDismiss={() => {
-            if (setUpCompleted) {
-              router.back();
-            }
-          }}
-        />
       </ScrollView>
+      <InfoAlert
+        {...modalState}
+        visible={modalVisible}
+        setVisible={setModalVisible}
+        onDismiss={() => {
+          if (setUpCompleted) {
+            router.back();
+          }
+        }}
+      />
     </View>
   );
 };

--- a/mobile/app/(Views)/settings/wallet-address.tsx
+++ b/mobile/app/(Views)/settings/wallet-address.tsx
@@ -107,102 +107,104 @@ const WalletAddress = () => {
     syncWalletAddress();
   }, []);
   return (
-    <ScrollView
-      contentContainerStyle={{ padding: 0 }}
-      keyboardShouldPersistTaps="handled"
-      className="bg-black-1000"
-    >
-      <View className="flex-1 bg-black-1000 h-full">
-        <View className="w-full max-w-5xl mx-auto justify-between">
-          <View className="items-center">
-            <BackButton />
-            <Text className="text-lg font-semibold text-white">
-              {t("settings.wallet_address")}
-            </Text>
-          </View>
+    <View style={{ flex: 1 }}>
+      <ScrollView
+        contentContainerStyle={{ padding: 0 }}
+        keyboardShouldPersistTaps="handled"
+        className="bg-black-1000"
+      >
+        <View className="flex-1 bg-black-1000 h-full">
+          <View className="w-full max-w-5xl mx-auto justify-between">
+            <View className="items-center">
+              <BackButton />
+              <Text className="text-lg font-semibold text-white">
+                {t("settings.wallet_address")}
+              </Text>
+            </View>
 
-          <View className="mt-10 mb-2">
-            <View className="w-full">
-              {/* QR Code */}
-              {/* <View className="bg-white p-4 border rounded-2xl mb-14">
-                <QRCode
-                  value={
-                    registeredAddresses.length > 0 ? registeredAddresses[0] : ""
-                  }
-                  size={200}
-                  backgroundColor="white"
-                  color="black"
-                  getRef={(c: any) => (qrRef.current = c as any)}
-                />
-              </View> */}
+            <View className="mt-10 mb-2">
+              <View className="w-full">
+                {/* QR Code */}
+                {/* <View className="bg-white p-4 border rounded-2xl mb-14">
+                  <QRCode
+                    value={
+                      registeredAddresses.length > 0 ? registeredAddresses[0] : ""
+                    }
+                    size={200}
+                    backgroundColor="white"
+                    color="black"
+                    getRef={(c: any) => (qrRef.current = c as any)}
+                  />
+                </View> */}
 
-              {/* Input with Copy Button */}
-              <View className="relative my-8">
-                <TextInput
-                  value={newAddress}
-                  placeholder={t("settings.enter_wallet_address")}
-                  placeholderTextColor="#6b7280"
-                  className="text-base pr-20 text-white font-semibold px-4 border border-gray-1000 w-full h-[53px] rounded-[6px]"
-                  onChangeText={setNewAddress}
-                />
-                <TouchableOpacity
-                  onPress={addWalletAddress}
-                  className="absolute top-1/2 -translate-y-1/2 right-3 bg-pink-1100 py-[5px] px-[8px] rounded-2xl"
-                >
-                  <Text className="text-white text-[14px] font-medium leading-[22px]">
-                    {t("settings.add")}
-                  </Text>
-                </TouchableOpacity>
-              </View>
-
-              {/* Instruction List */}
-              <View className="px-6">
-                <View className="flex-row items-center mb-1 gap-2.5">
-                  <View className="w-5 h-5 border border-white !rounded-full items-center justify-center">
-                    <Text className="text-white flex text-xs">1</Text>
-                  </View>
-                  <Text className="text-[15px] font-normal leading-5 text-gray-1000">
-                    {t("settings.wallet_address_instruction_1")}
-                  </Text>
+                {/* Input with Copy Button */}
+                <View className="relative my-8">
+                  <TextInput
+                    value={newAddress}
+                    placeholder={t("settings.enter_wallet_address")}
+                    placeholderTextColor="#6b7280"
+                    className="text-base pr-20 text-white font-semibold px-4 border border-gray-1000 w-full h-[53px] rounded-[6px]"
+                    onChangeText={setNewAddress}
+                  />
+                  <TouchableOpacity
+                    onPress={addWalletAddress}
+                    className="absolute top-1/2 -translate-y-1/2 right-3 bg-pink-1100 py-[5px] px-[8px] rounded-2xl"
+                  >
+                    <Text className="text-white text-[14px] font-medium leading-[22px]">
+                      {t("settings.add")}
+                    </Text>
+                  </TouchableOpacity>
                 </View>
-                <View className="flex-row items-center mb-1 gap-2.5">
-                  <View className="w-5 h-5 border border-white !rounded-full items-center justify-center">
-                    <Text className="text-white flex text-xs">2</Text>
+
+                {/* Instruction List */}
+                <View className="px-6">
+                  <View className="flex-row items-center mb-1 gap-2.5">
+                    <View className="w-5 h-5 border border-white !rounded-full items-center justify-center">
+                      <Text className="text-white flex text-xs">1</Text>
+                    </View>
+                    <Text className="text-[15px] font-normal leading-5 text-gray-1000">
+                      {t("settings.wallet_address_instruction_1")}
+                    </Text>
                   </View>
-                  <Text className="text-[15px] font-normal leading-5 text-gray-1000">
-                    {t("settings.wallet_address_instruction_2")}
-                  </Text>
-                </View>
-                <View className="flex-row items-center mb-1 gap-2.5">
-                  <View className="w-5 h-5 border border-white !rounded-full items-center justify-center">
-                    <Text className="text-white flex text-xs">3</Text>
+                  <View className="flex-row items-center mb-1 gap-2.5">
+                    <View className="w-5 h-5 border border-white !rounded-full items-center justify-center">
+                      <Text className="text-white flex text-xs">2</Text>
+                    </View>
+                    <Text className="text-[15px] font-normal leading-5 text-gray-1000">
+                      {t("settings.wallet_address_instruction_2")}
+                    </Text>
                   </View>
-                  <Text className="text-[15px] font-normal leading-5 text-gray-1000">
-                    {t("settings.wallet_address_instruction_3")}
-                  </Text>
+                  <View className="flex-row items-center mb-1 gap-2.5">
+                    <View className="w-5 h-5 border border-white !rounded-full items-center justify-center">
+                      <Text className="text-white flex text-xs">3</Text>
+                    </View>
+                    <Text className="text-[15px] font-normal leading-5 text-gray-1000">
+                      {t("settings.wallet_address_instruction_3")}
+                    </Text>
+                  </View>
                 </View>
               </View>
             </View>
+            <View className="flex-row items-center gap-2 mb-2 mt-2">
+              <View className="w-6 h-6 rounded-full bg-black-1200 border-[5px] border-gray-1100" />
+              <Text className="text-base font-medium text-white">
+                {t("common.wallet_address")} ({registeredAddresses.length})
+              </Text>
+            </View>
+            <DepositAddressList
+              handleDelete={deleteAddress}
+              handleCopy={handleCopy}
+              addresses={registeredAddresses}
+            />
           </View>
-          <View className="flex-row items-center gap-2 mb-2 mt-2">
-            <View className="w-6 h-6 rounded-full bg-black-1200 border-[5px] border-gray-1100" />
-            <Text className="text-base font-medium text-white">
-              {t("common.wallet_address")} ({registeredAddresses.length})
-            </Text>
-          </View>
-          <DepositAddressList
-            handleDelete={deleteAddress}
-            handleCopy={handleCopy}
-            addresses={registeredAddresses}
-          />
         </View>
-      </View>
+      </ScrollView>
       <InfoAlert
         {...modalState}
         visible={modalVisible}
         setVisible={setModalVisible}
       />
-    </ScrollView>
+    </View>
   );
 };
 

--- a/mobile/app/(Views)/staking/enroll-plan.tsx
+++ b/mobile/app/(Views)/staking/enroll-plan.tsx
@@ -363,20 +363,20 @@ const EnrollPlan = () => {
               </View>
             </Modal>
 
-            <InfoAlert
-              {...modalState}
-              visible={popupVisible}
-              setVisible={setPopupVisible}
-              onDismiss={() => {
-                if (enrollmentSucces) {
-                  router.dismiss();
-                  router.navigate("/(Tabs)/staking");
-                }
-              }}
-            />
-            <OtpModal visible={otpModalVisible} onClose={handleOtpSubmit} />
           </View>
         </ScrollView>
+        <InfoAlert
+          {...modalState}
+          visible={popupVisible}
+          setVisible={setPopupVisible}
+          onDismiss={() => {
+            if (enrollmentSucces) {
+              router.dismiss();
+              router.navigate("/(Tabs)/staking");
+            }
+          }}
+        />
+        <OtpModal visible={otpModalVisible} onClose={handleOtpSubmit} />
       </KeyboardAvoidingView>
     </View>
   );

--- a/mobile/app/(Views)/staking/staking-plans.tsx
+++ b/mobile/app/(Views)/staking/staking-plans.tsx
@@ -180,10 +180,10 @@ const StakingPlans = () => {
           className="rounded-full flex-1 overflow-hidden" // Removed shadow-lg
         >
           <LinearGradient
-            colors={["#8B5CF6", "#9333EA", "#4F46E5"]} // from-purple-500, via-purple-600, to-indigo-600
+            colors={["#8B5CF6", "#9333EA", "#4F46E5"]}
             start={{ x: 0, y: 0 }}
             end={{ x: 1, y: 0 }}
-            className="py-2 px-4 rounded-full items-center"
+            style={{ paddingVertical: 8, paddingHorizontal: 16, borderRadius: 999, alignItems: "center", justifyContent: "center" }}
           >
             <Text className="text-white font-bold text-base">
               {t("staking.staking").toUpperCase()}
@@ -200,10 +200,10 @@ const StakingPlans = () => {
           className="rounded-full transition-transform hover:scale-105 flex-1 overflow-hidden" // Removed shadow-lg
         >
           <LinearGradient
-            colors={["#D1D5DB", "#9CA3AF", "#6B7280"]} // from-gray-300, via-gray-400, to-gray-600
+            colors={["#D1D5DB", "#9CA3AF", "#6B7280"]}
             start={{ x: 0, y: 0 }}
             end={{ x: 1, y: 0 }}
-            className="py-2 px-4 rounded-full items-center"
+            style={{ paddingVertical: 8, paddingHorizontal: 16, borderRadius: 999, alignItems: "center", justifyContent: "center" }}
           >
             <Text className="text-black font-bold text-base">
               {t("components.unstaking").toUpperCase()}

--- a/mobile/app/(Views)/withdrawal-view.tsx
+++ b/mobile/app/(Views)/withdrawal-view.tsx
@@ -118,64 +118,64 @@ const WithDrawal = () => {
     setWithdrawAmount(amount.toString());
   };
 
+  const showError = (text: string) => {
+    setInfoAlertState({ type: "error", text });
+    setInfoAlertVisible(true);
+  };
+
   const handleNext = () => {
     if (!withdrawalAddress || !isValidPublicKey(withdrawalAddress)) {
-      setInfoAlertState({
-        type: "error",
-        text: t("withdrawal.invalid_address"),
-      });
-      setInfoAlertVisible(true);
+      showError(t("withdrawal.invalid_address"));
       return;
     }
 
     if (!withdrawAmount || isNaN(Number(withdrawAmount))) {
-      setInfoAlertState({
-        type: "error",
-        text: t("withdrawal.invalid_amount"),
+      showError(t("withdrawal.invalid_amount"));
+      return;
+    }
+
+    try {
+      const amount = new Decimal(withdrawAmount);
+
+      if (minWithdrawl != null && amount.lessThan(minWithdrawl)) {
+        showError(
+          t("withdrawal.min_amount_error", {
+            amount: minWithdrawl,
+            symbol: displaySymbol,
+          })
+        );
+        return;
+      }
+
+      if (freeBalance != null && amount.greaterThan(freeBalance)) {
+        showError(
+          t("withdrawal.insufficient_balance", {
+            balance: freeBalance,
+            symbol: displaySymbol,
+          })
+        );
+        return;
+      }
+
+      if (
+        amount.greaterThanOrEqualTo(KYC_REQUIRED_THRESHOLD) &&
+        !kycCompleted
+      ) {
+        router.replace("/(Views)/kyc/ready");
+        return;
+      }
+
+      router.push({
+        pathname: "/confirm-withdrawl",
+        params: {
+          symbol: symbol,
+          amount: amount.toString(),
+          address: withdrawalAddress,
+        },
       });
-      setInfoAlertVisible(true);
-      return;
+    } catch {
+      showError(t("withdrawal.invalid_amount"));
     }
-
-    const amount = new Decimal(withdrawAmount);
-
-    if (amount.lessThan(minWithdrawl)) {
-      setInfoAlertState({
-        type: "error",
-        text: t("withdrawal.min_amount_error", {
-          amount: minWithdrawl,
-          symbol: displaySymbol,
-        }),
-      });
-      setInfoAlertVisible(true);
-      return;
-    }
-
-    if (amount.greaterThan(freeBalance)) {
-      setInfoAlertState({
-        type: "error",
-        text: t("withdrawal.insufficient_balance", {
-          balance: freeBalance,
-          symbol: displaySymbol,
-        }),
-      });
-      setInfoAlertVisible(true);
-      return;
-    }
-
-    if (amount.greaterThanOrEqualTo(KYC_REQUIRED_THRESHOLD) && !kycCompleted) {
-      router.replace("/(Views)/kyc/ready");
-      return;
-    }
-
-    router.push({
-      pathname: "/confirm-withdrawl",
-      params: {
-        symbol: symbol,
-        amount: amount.toString(),
-        address: withdrawalAddress,
-      },
-    });
   };
 
   useEffect(() => {
@@ -308,23 +308,25 @@ const WithDrawal = () => {
                 </View>
               </View>
 
-              <View className="mx-1 mb-3 px-4 py-3 rounded-[12px] bg-yellow-500/10 border border-yellow-500/30">
-                <Text className="text-yellow-400 text-sm text-center">
-                  {t("withdrawal.kyc_required_above")}
-                </Text>
-              </View>
+              {!kycCompleted && (
+                <View className="mx-1 mb-3 px-4 py-3 rounded-[12px] bg-yellow-500/10 border border-yellow-500/30">
+                  <Text className="text-yellow-400 text-sm text-center">
+                    {t("withdrawal.kyc_required_above")}
+                  </Text>
+                </View>
+              )}
 
               <PrimaryButton text={t("withdrawal.next")} onPress={handleNext} />
             </View>
           </View>
-          <QRModal visible={qrScanVisible} onClose={handleQRData} />
-          <InfoAlert
-            {...infoAlertState}
-            visible={infoAlertVisible}
-            setVisible={setInfoAlertVisible}
-          />
         </ScrollView>
       </KeyboardAvoidingView>
+      <QRModal visible={qrScanVisible} onClose={handleQRData} />
+      <InfoAlert
+        {...infoAlertState}
+        visible={infoAlertVisible}
+        setVisible={setInfoAlertVisible}
+      />
     </View>
   );
 };

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -7,7 +7,6 @@ import * as SplashScreen from "expo-splash-screen";
 import React, { useCallback, useEffect, useState } from "react";
 import { Linking } from "react-native";
 import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
-import Toast from "react-native-toast-message";
 import "./global.css";
 import MyStatusBar from "./components/AppStatusBar";
 import { Provider } from "react-redux";
@@ -103,7 +102,6 @@ export default function RootLayout() {
               </Stack>
               <LoadingOverlay />
               <InfoOverlay />
-              <Toast />
             </SafeAreaView>
           </SafeAreaProvider>
         </GluestackUIProvider>

--- a/mobile/app/components/ActionPopup.tsx
+++ b/mobile/app/components/ActionPopup.tsx
@@ -12,7 +12,6 @@ import {
 } from "react-native";
 import { useTranslation } from "react-i18next";
 import SvgIcon from "@/app/components/SvgIcon";
-import { Portal } from "react-native-paper";
 import InfoAlert from "@/app/components/InfoAlert";
 
 interface ActionPopupProps {

--- a/mobile/app/components/BalanceYieldGuide.tsx
+++ b/mobile/app/components/BalanceYieldGuide.tsx
@@ -1,13 +1,13 @@
-// components/BalanceYieldGuide.tsx
 import React, { useEffect, useRef } from "react";
 import {
-  View,
-  Text,
-  ScrollView,
   Animated,
+  Modal,
+  Pressable,
+  ScrollView,
+  Text,
   TouchableOpacity,
+  View,
 } from "react-native";
-import { Portal } from "react-native-paper";
 
 interface BalanceYieldGuideProps {
   visible: boolean;
@@ -18,81 +18,77 @@ const BalanceYieldGuide: React.FC<BalanceYieldGuideProps> = ({
   visible,
   onDismiss,
 }) => {
-  const scaleAnim = useRef(new Animated.Value(0.8)).current;
-  const opacityAnim = useRef(new Animated.Value(0)).current;
+  const scaleAnim = useRef(new Animated.Value(0.95)).current;
 
   useEffect(() => {
     if (visible) {
-      Animated.parallel([
-        Animated.spring(scaleAnim, {
-          toValue: 1,
-          useNativeDriver: true,
-        }),
-        Animated.timing(opacityAnim, {
-          toValue: 1,
-          duration: 200,
-          useNativeDriver: true,
-        }),
-      ]).start();
+      scaleAnim.setValue(0.95);
+      Animated.spring(scaleAnim, { toValue: 1, useNativeDriver: true, bounciness: 4 }).start();
     } else {
-      opacityAnim.setValue(0);
-      scaleAnim.setValue(0.8);
+      scaleAnim.setValue(0.95);
     }
   }, [visible]);
 
-  if (!visible) return null;
-
   return (
-    <Portal>
-      <View className="flex-1 items-center justify-center bg-[rgba(31,31,31,0.5)] absolute top-0 bottom-0 left-0 right-0 z-50">
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onDismiss}
+      statusBarTranslucent
+    >
+      <Pressable
+        className="flex-1 items-center justify-center"
+        style={{ backgroundColor: "rgba(31,31,31,0.5)" }}
+        onPress={onDismiss}
+      >
         <Animated.View
-          style={{
-            transform: [{ scale: scaleAnim }],
-            opacity: opacityAnim,
-          }}
+          style={{ transform: [{ scale: scaleAnim }] }}
           className="bg-[#191919] rounded-2xl px-6 py-8 w-[85%] max-h-[80%]"
         >
-          <ScrollView
-            showsVerticalScrollIndicator={false}
-            contentContainerStyle={{ paddingBottom: 4 }}
-          >
-            <Text className="text-white text-xl font-semibold mb-4 text-center">
-              Balance Yield Guide
-            </Text>
+          <Pressable onPress={() => {}}>
+            <ScrollView
+              showsVerticalScrollIndicator={false}
+              contentContainerStyle={{ paddingBottom: 4 }}
+            >
+              <Text className="text-white text-xl font-semibold mb-4 text-center">
+                Balance Yield Guide
+              </Text>
 
-            <Text className="text-gray-300 text-base leading-6 mb-3">
-              • After receiving, your Balance Yield will display as{" "}
-              <Text className="font-semibold text-white">0</Text>.
-            </Text>
+              <Text className="text-gray-300 text-base leading-6 mb-3">
+                • After receiving, your Balance Yield will display as{" "}
+                <Text className="font-semibold text-white">0</Text>.
+              </Text>
 
-            <Text className="text-gray-300 text-base leading-6 mb-3">
-              • Deposit details can be found in the transaction history, and the
-              amount is added to your{" "}
-              <Text className="font-semibold text-white">USDT balance</Text>.
-            </Text>
+              <Text className="text-gray-300 text-base leading-6 mb-3">
+                • Deposit details can be found in the transaction history, and
+                the amount is added to your{" "}
+                <Text className="font-semibold text-white">USDT balance</Text>.
+              </Text>
 
-            <Text className="text-gray-300 text-base leading-6 mb-3">
-              • If the deposit is not visible, it may be under maintenance or
-              being processed sequentially. Please check again later.
-            </Text>
+              <Text className="text-gray-300 text-base leading-6 mb-3">
+                • If the deposit is not visible, it may be under maintenance or
+                being processed sequentially. Please check again later.
+              </Text>
 
-            <Text className="text-gray-300 text-base leading-6">
-              • Balance Yield is paid{" "}
-              <Text className="font-semibold text-white">net of taxes</Text>.
-            </Text>
+              <Text className="text-gray-300 text-base leading-6">
+                • Balance Yield is paid{" "}
+                <Text className="font-semibold text-white">net of taxes</Text>.
+              </Text>
 
-            <View className="mt-6 ml-auto">
-              <TouchableOpacity
-                onPress={onDismiss}
-                className="bg-black-1200 px-4 py-2 rounded-xl"
-              >
-                <Text className="text-white font-medium">OK</Text>
-              </TouchableOpacity>
-            </View>
-          </ScrollView>
+              <View className="mt-6 ml-auto">
+                <TouchableOpacity
+                  onPress={onDismiss}
+                  className="bg-black-1200 px-4 py-2 rounded-xl"
+                >
+                  <Text className="text-white font-medium">OK</Text>
+                </TouchableOpacity>
+              </View>
+            </ScrollView>
+          </Pressable>
         </Animated.View>
-      </View>
-    </Portal>
+      </Pressable>
+    </Modal>
   );
 };
 

--- a/mobile/app/components/DialogAlert.tsx
+++ b/mobile/app/components/DialogAlert.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import { View, Text, Animated, TouchableOpacity } from "react-native";
+import { Animated, Modal, Pressable, Text, TouchableOpacity, View } from "react-native";
 import { useTranslation } from "react-i18next";
 
 interface Props {
@@ -20,74 +20,64 @@ const DialogAlert = ({
   showAnimation = true,
 }: Props) => {
   const { t } = useTranslation();
-  const scaleAnim = useRef(new Animated.Value(0.8)).current;
-  const opacityAnim = useRef(new Animated.Value(0)).current;
+  const scaleAnim = useRef(new Animated.Value(0.95)).current;
 
   useEffect(() => {
     if (visible) {
-      if (!showAnimation) {
-        scaleAnim.setValue(1);
-        opacityAnim.setValue(1);
-      }
-      Animated.parallel([
-        Animated.spring(scaleAnim, {
-          toValue: 1,
-          useNativeDriver: true,
-        }),
-        Animated.timing(opacityAnim, {
-          toValue: 1,
-          duration: 200,
-          useNativeDriver: true,
-        }),
-      ]).start();
+      scaleAnim.setValue(showAnimation ? 0.95 : 1);
+      Animated.spring(scaleAnim, { toValue: 1, useNativeDriver: true, bounciness: 4 }).start();
     } else {
-      opacityAnim.setValue(0);
-      scaleAnim.setValue(0.8);
+      scaleAnim.setValue(0.95);
     }
   }, [visible]);
 
-  if (!visible) return null;
-
   return (
-    <View className="flex-1 items-center justify-center bg-[rgba(31,31,31,0.5)] px-3 absolute top-0 bottom-0 h-full w-full z-50">
-      <Animated.View
-        style={{
-          transform: [{ scale: scaleAnim }],
-          opacity: opacityAnim,
-        }}
-        className="bg-[#191919] rounded-[16px] px-4 pb-8 pt-10 w-full"
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={() => setVisible(false)}
+      statusBarTranslucent
+    >
+      <Pressable
+        className="flex-1 items-center justify-center px-3"
+        style={{ backgroundColor: "rgba(31,31,31,0.5)" }}
+        onPress={() => setVisible(false)}
       >
-        <View className="flex gap-4">
-          <Text className="text-white text-center text-lg">{text}</Text>
-          <View className="flex flex-row">
-            <View className="flex-row items-center justify-center gap-2 px-6">
-              <TouchableOpacity
-                onPress={() => {
-                  setVisible(false);
-                  if (onConfirm) {
-                    onConfirm();
-                  }
-                }}
-                className="w-1/2 h-[45px] bg-pink-1100 rounded-[15px] justify-center items-center border border-blue-1100"
-              >
-                <Text className="text-white font-semibold">{t('common.yes')}</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
-                onPress={() => {
-                  setVisible(false);
-                  if (onReject) {
-                    onReject();
-                  }
-                }}
-                className="w-1/2 h-[45px] bg-black-1100 rounded-[15px] justify-center items-center"
-              >
-                <Text className="text-white font-semibold">{t('common.no')}</Text>
-              </TouchableOpacity>
+        <Animated.View
+          style={{ transform: [{ scale: scaleAnim }] }}
+          className="bg-[#191919] rounded-[16px] px-4 pb-8 pt-10 w-full"
+        >
+          <Pressable onPress={() => {}}>
+            <View className="flex gap-4">
+              <Text className="text-white text-center text-lg">{text}</Text>
+              <View className="flex flex-row">
+                <View className="flex-row items-center justify-center gap-2 px-6">
+                  <TouchableOpacity
+                    onPress={() => {
+                      setVisible(false);
+                      if (onConfirm) onConfirm();
+                    }}
+                    className="w-1/2 h-[45px] bg-pink-1100 rounded-[15px] justify-center items-center border border-blue-1100"
+                  >
+                    <Text className="text-white font-semibold">{t("common.yes")}</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    onPress={() => {
+                      setVisible(false);
+                      if (onReject) onReject();
+                    }}
+                    className="w-1/2 h-[45px] bg-black-1100 rounded-[15px] justify-center items-center"
+                  >
+                    <Text className="text-white font-semibold">{t("common.no")}</Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
             </View>
-          </View>
-        </View>
-      </Animated.View>
-    </View>
+          </Pressable>
+        </Animated.View>
+      </Pressable>
+    </Modal>
   );
 };
 

--- a/mobile/app/components/InfoAlert.tsx
+++ b/mobile/app/components/InfoAlert.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef } from "react";
-import { View, Text, Animated } from "react-native";
+import { Animated, Modal, Pressable, Text, View } from "react-native";
 import PrimaryButton from "./PrimaryButton";
-import { Portal } from "react-native-paper";
 import { useTranslation } from "react-i18next";
 
 export interface InfoAlertProps {
@@ -26,64 +25,56 @@ const InfoAlert = ({
   primaryButtonText,
 }: InfoAlertProps) => {
   const { t } = useTranslation();
-  const scaleAnim = useRef(new Animated.Value(0.8)).current;
-  const opacityAnim = useRef(new Animated.Value(0)).current;
+  const scaleAnim = useRef(new Animated.Value(0.95)).current;
 
   useEffect(() => {
     if (visible) {
-      if (!showAnimation) {
-        scaleAnim.setValue(1);
-        opacityAnim.setValue(1);
-      }
-      Animated.parallel([
-        Animated.spring(scaleAnim, {
-          toValue: 1,
-          useNativeDriver: true,
-        }),
-        Animated.timing(opacityAnim, {
-          toValue: 1,
-          duration: 200,
-          useNativeDriver: true,
-        }),
-      ]).start();
+      scaleAnim.setValue(showAnimation ? 0.95 : 1);
+      Animated.spring(scaleAnim, {
+        toValue: 1,
+        useNativeDriver: true,
+        bounciness: 4,
+      }).start();
     } else {
-      opacityAnim.setValue(0);
-      scaleAnim.setValue(0.8);
+      scaleAnim.setValue(0.95);
     }
   }, [visible]);
 
-  if (!visible) return null;
+  const buttonText = primaryButtonText ?? t("common.ok");
 
-  const buttonText = primaryButtonText ? primaryButtonText : t("common.ok");
+  const dismiss = () => {
+    setVisible(false);
+    if (onDismiss) onDismiss();
+  };
 
   return (
-    <Portal>
-      <View
-        className="flex-1 items-center justify-center bg-[rgba(31,31,31,0.5)] px-3 absolute top-0 bottom-0 h-full w-full"
-        style={{ zIndex: 1000 }}
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={cancellable ? dismiss : undefined}
+      statusBarTranslucent
+    >
+      <Pressable
+        className="flex-1 items-center justify-center px-3"
+        style={{ backgroundColor: "rgba(31,31,31,0.6)" }}
+        onPress={cancellable ? dismiss : undefined}
       >
         <Animated.View
-          style={{
-            transform: [{ scale: scaleAnim }],
-            opacity: opacityAnim,
-          }}
+          style={{ transform: [{ scale: scaleAnim }] }}
           className="bg-[#191919] rounded-[16px] px-4 pb-8 pt-10 w-full"
         >
-          <View className="flex gap-4">
-            <Text className="text-white text-center text-lg">{text}</Text>
-            {cancellable && (
-              <PrimaryButton
-                text={buttonText}
-                onPress={() => {
-                  setVisible(false);
-                  if (onDismiss) onDismiss();
-                }}
-              />
-            )}
-          </View>
+          <Pressable onPress={() => {}}>
+            <View className="flex gap-4">
+              <Text className="text-white text-center text-lg">{text}</Text>
+              {cancellable && (
+                <PrimaryButton text={buttonText} onPress={dismiss} />
+              )}
+            </View>
+          </Pressable>
         </Animated.View>
-      </View>
-    </Portal>
+      </Pressable>
+    </Modal>
   );
 };
 

--- a/mobile/app/components/InfoPopup.tsx
+++ b/mobile/app/components/InfoPopup.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useRef } from "react";
 import {
-  View,
-  Text,
-  ScrollView,
   Animated,
+  Modal,
+  Pressable,
+  ScrollView,
+  Text,
   TouchableOpacity,
+  View,
 } from "react-native";
-import { Portal } from "react-native-paper";
 import SvgIcon from "./SvgIcon";
 
 type PopupType = "error" | "success" | "info";
@@ -21,10 +22,13 @@ interface InfoPopupProps {
   onAction?: () => void;
 }
 
-const TYPE_CONFIG: Record<PopupType, { icon: Parameters<typeof SvgIcon>[0]["name"]; color: string }> = {
-  error:   { icon: "errorIcon",   color: "#ef4444" },
+const TYPE_CONFIG: Record<
+  PopupType,
+  { icon: Parameters<typeof SvgIcon>[0]["name"]; color: string }
+> = {
+  error: { icon: "errorIcon", color: "#ef4444" },
   success: { icon: "successIcon", color: "#22c55e" },
-  info:    { icon: "infoIcon",    color: "#60a5fa" },
+  info: { icon: "infoIcon", color: "#60a5fa" },
 };
 
 const InfoPopup: React.FC<InfoPopupProps> = ({
@@ -37,85 +41,83 @@ const InfoPopup: React.FC<InfoPopupProps> = ({
   onAction,
 }) => {
   const typeConfig = type ? TYPE_CONFIG[type] : null;
-  const scaleAnim = useRef(new Animated.Value(0.8)).current;
-  const opacityAnim = useRef(new Animated.Value(0)).current;
+  const scaleAnim = useRef(new Animated.Value(0.95)).current;
 
   useEffect(() => {
     if (visible) {
-      Animated.parallel([
-        Animated.spring(scaleAnim, {
-          toValue: 1,
-          useNativeDriver: true,
-        }),
-        Animated.timing(opacityAnim, {
-          toValue: 1,
-          duration: 200,
-          useNativeDriver: true,
-        }),
-      ]).start();
+      scaleAnim.setValue(0.95);
+      Animated.spring(scaleAnim, { toValue: 1, useNativeDriver: true, bounciness: 4 }).start();
     } else {
-      opacityAnim.setValue(0);
-      scaleAnim.setValue(0.8);
+      scaleAnim.setValue(0.95);
     }
   }, [visible]);
 
-  if (!visible) return null;
-
   return (
-    <Portal>
-      <View className="flex-1 items-center justify-center bg-[rgba(31,31,31,0.5)] absolute top-0 bottom-0 left-0 right-0 z-50">
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onDismiss}
+      statusBarTranslucent
+    >
+      <Pressable
+        className="flex-1 items-center justify-center"
+        style={{ backgroundColor: "rgba(31,31,31,0.5)" }}
+        onPress={onDismiss}
+      >
         <Animated.View
-          style={{
-            transform: [{ scale: scaleAnim }],
-            opacity: opacityAnim,
-          }}
+          style={{ transform: [{ scale: scaleAnim }] }}
           className="bg-[#191919] rounded-2xl px-6 py-8 w-[85%] max-h-[80%]"
         >
-          <ScrollView
-            showsVerticalScrollIndicator={false}
-            contentContainerStyle={{ paddingBottom: 4 }}
-          >
-            <View className="flex-row items-center justify-center gap-2 mb-8">
-              {typeConfig && (
-                <SvgIcon
-                  name={typeConfig.icon}
-                  width="22"
-                  height="22"
-                  color={typeConfig.color}
-                />
-              )}
-              <Text
-                className="text-white text-xl font-semibold text-center"
-                style={typeConfig ? { color: typeConfig.color } : undefined}
-              >
-                {title}
-              </Text>
-            </View>
-
-            <Text className="text-gray-300 text-base leading-6 mb-3 text-center">
-              {content}
-            </Text>
-
-            <View className="mt-6 flex-row justify-end gap-3">
-              {actionLabel && onAction && (
-                <TouchableOpacity
-                  onPress={onAction}
-                  className="bg-pink-1100/20 border border-pink-1100 px-4 py-2 rounded-xl"
+          <Pressable onPress={() => {}}>
+            <ScrollView
+              showsVerticalScrollIndicator={false}
+              contentContainerStyle={{ paddingBottom: 4 }}
+            >
+              <View className="flex-row items-center justify-center gap-2 mb-8">
+                {typeConfig && (
+                  <SvgIcon
+                    name={typeConfig.icon}
+                    width="22"
+                    height="22"
+                    color={typeConfig.color}
+                  />
+                )}
+                <Text
+                  className="text-white text-xl font-semibold text-center"
+                  style={typeConfig ? { color: typeConfig.color } : undefined}
                 >
-                  <Text className="text-pink-1100 font-medium">{actionLabel}</Text>
+                  {title}
+                </Text>
+              </View>
+
+              <Text className="text-gray-300 text-base leading-6 mb-3 text-center">
+                {content}
+              </Text>
+
+              <View className="mt-6 flex-row justify-end gap-3">
+                {actionLabel && onAction && (
+                  <TouchableOpacity
+                    onPress={onAction}
+                    className="bg-pink-1100/20 border border-pink-1100 px-4 py-2 rounded-xl"
+                  >
+                    <Text className="text-pink-1100 font-medium">
+                      {actionLabel}
+                    </Text>
+                  </TouchableOpacity>
+                )}
+                <TouchableOpacity
+                  onPress={onDismiss}
+                  className="bg-black-1200 px-4 py-2 rounded-xl"
+                >
+                  <Text className="text-white font-medium">OK</Text>
                 </TouchableOpacity>
-              )}
-              <TouchableOpacity
-                onPress={onDismiss}
-                className="bg-black-1200 px-4 py-2 rounded-xl"
-              >
-                <Text className="text-white font-medium">OK</Text>
-              </TouchableOpacity>
-            </View>
-          </ScrollView>
+              </View>
+            </ScrollView>
+          </Pressable>
         </Animated.View>
-      </View>
-    </Portal>
+      </Pressable>
+    </Modal>
   );
 };
 

--- a/mobile/app/components/LoadingOverlay.tsx
+++ b/mobile/app/components/LoadingOverlay.tsx
@@ -1,21 +1,19 @@
-// components/LoadingOverlay.tsx
 import { RootState } from "@/src/store";
 import React, { useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  View,
-  Text,
-  Animated,
   ActivityIndicator,
+  Animated,
   Keyboard,
+  Modal,
+  Text,
+  View,
 } from "react-native";
-import { Portal } from "react-native-paper";
 import { useSelector } from "react-redux";
 
 const LoadingOverlay = () => {
   const { visible, text } = useSelector((state: RootState) => state.progress);
-  const scaleAnim = useRef(new Animated.Value(0.8)).current;
-  const opacityAnim = useRef(new Animated.Value(0)).current;
+  const scaleAnim = useRef(new Animated.Value(0.95)).current;
   const { t } = useTranslation();
 
   const displayText = useMemo(() => {
@@ -26,38 +24,26 @@ const LoadingOverlay = () => {
   useEffect(() => {
     if (visible) {
       Keyboard.dismiss();
-    }
-  }, [visible]);
-
-  useEffect(() => {
-    if (visible) {
-      Animated.parallel([
-        Animated.spring(scaleAnim, {
-          toValue: 1,
-          useNativeDriver: true,
-        }),
-        Animated.timing(opacityAnim, {
-          toValue: 1,
-          duration: 200,
-          useNativeDriver: true,
-        }),
-      ]).start();
+      scaleAnim.setValue(0.95);
+      Animated.spring(scaleAnim, { toValue: 1, useNativeDriver: true, bounciness: 4 }).start();
     } else {
-      opacityAnim.setValue(0);
-      scaleAnim.setValue(0.8);
+      scaleAnim.setValue(0.95);
     }
   }, [visible]);
-
-  if (!visible) return null;
 
   return (
-    <Portal>
-      <View className="flex-1 items-center justify-center bg-[rgba(31,31,31,0.5)] absolute top-0 bottom-0 h-full w-full z-50">
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      statusBarTranslucent
+    >
+      <View
+        className="flex-1 items-center justify-center"
+        style={{ backgroundColor: "rgba(31,31,31,0.5)" }}
+      >
         <Animated.View
-          style={{
-            transform: [{ scale: scaleAnim }],
-            opacity: opacityAnim,
-          }}
+          style={{ transform: [{ scale: scaleAnim }] }}
           className="bg-[#191919] rounded-[16px] px-6 py-10 w-[80%] items-center"
         >
           <ActivityIndicator size="large" color="#ffffff" />
@@ -66,7 +52,7 @@ const LoadingOverlay = () => {
           </Text>
         </Animated.View>
       </View>
-    </Portal>
+    </Modal>
   );
 };
 

--- a/mobile/app/components/OTPModal.tsx
+++ b/mobile/app/components/OTPModal.tsx
@@ -1,17 +1,13 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useState } from "react";
 import {
-  View,
+  Modal,
   Text,
   TextInput,
   TouchableOpacity,
-  Animated,
-  Dimensions,
+  View,
 } from "react-native";
 import PrimaryButton from "./PrimaryButton";
-import { Portal } from "react-native-paper";
 import { useTranslation } from "react-i18next";
-
-const { height } = Dimensions.get("window");
 
 interface OtpModalProps {
   visible: boolean;
@@ -23,27 +19,6 @@ const OtpModal: React.FC<OtpModalProps> = ({ visible, onClose }) => {
   const [otp, setOtp] = useState("");
   const [error, setError] = useState<string | null>(null);
 
-  const translateY = useRef(new Animated.Value(height)).current;
-
-  useEffect(() => {
-    if (visible) {
-      Animated.timing(translateY, {
-        toValue: 0,
-        duration: 300,
-        useNativeDriver: true,
-      }).start();
-    } else {
-      Animated.timing(translateY, {
-        toValue: height,
-        duration: 300,
-        useNativeDriver: true,
-      }).start(() => {
-        setOtp("");
-        setError(null);
-      });
-    }
-  }, [visible]);
-
   const handleClose = () => {
     onClose(null);
     setOtp("");
@@ -52,7 +27,7 @@ const OtpModal: React.FC<OtpModalProps> = ({ visible, onClose }) => {
 
   const onSubmit = () => {
     if (!otp || otp.length < 6) {
-      setError(t('components.otp_error'));
+      setError(t("components.otp_error"));
       return;
     }
     onClose(otp);
@@ -60,46 +35,49 @@ const OtpModal: React.FC<OtpModalProps> = ({ visible, onClose }) => {
     setError(null);
   };
 
-  if (!visible) return null;
-
   return (
-    <Portal>
-      <View className="absolute  top-0 bottom-0 left-0 right-0 bg-[rgba(31,31,31,0.5)] z-50">
-        <Animated.View
-          style={{
-            transform: [{ translateY }],
-          }}
-          className="flex-1 bg-black-1000 px-4 justify-center"
-        >
-          <View className="flex gap-4">
-            <Text className="text-xl text-white font-semibold text-center mb-4">
-              {t('components.enter_verification_code')}
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={handleClose}
+      statusBarTranslucent
+    >
+      <View
+        className="flex-1 justify-center px-4"
+        style={{ backgroundColor: "rgba(31,31,31,0.85)" }}
+      >
+        <View className="bg-black-1000 rounded-[16px] px-4 py-8 flex gap-4">
+          <Text className="text-xl text-white font-semibold text-center mb-4">
+            {t("components.enter_verification_code")}
+          </Text>
+
+          <TextInput
+            value={otp}
+            onChangeText={(text) => {
+              setOtp(text);
+              if (error) setError(null);
+            }}
+            placeholder={t("components.enter_otp")}
+            placeholderTextColor="#6b7280"
+            keyboardType="number-pad"
+            className="text-[17px] placeholder:text-gray-500 text-white font-medium px-4 bg-black-1200 w-full h-[55px] rounded-[10px] mb-2"
+          />
+
+          {error && (
+            <Text className="text-red-500 text-sm text-center">{error}</Text>
+          )}
+
+          <PrimaryButton text={t("components.submit")} onPress={onSubmit} />
+
+          <TouchableOpacity onPress={handleClose} className="mt-2">
+            <Text className="text-gray-400 text-center">
+              {t("common.cancel")}
             </Text>
-
-            <TextInput
-              value={otp}
-              onChangeText={(text) => {
-                setOtp(text);
-                if (error) setError(null);
-              }}
-              placeholder={t('components.enter_otp')}
-              keyboardType="number-pad"
-              className="text-[17px] placeholder:text-gray-500 text-white font-medium px-4 bg-black-1200 w-full h-[55px] rounded-[10px] mb-2"
-            />
-
-            {error && (
-              <Text className="text-red-500 text-sm text-center">{error}</Text>
-            )}
-
-            <PrimaryButton text={t('components.submit')} onPress={onSubmit} />
-
-            <TouchableOpacity onPress={handleClose} className="mt-2">
-              <Text className="text-gray-400 text-center">{t('common.cancel')}</Text>
-            </TouchableOpacity>
-          </View>
-        </Animated.View>
+          </TouchableOpacity>
+        </View>
       </View>
-    </Portal>
+    </Modal>
   );
 };
 

--- a/mobile/app/components/QRModal.tsx
+++ b/mobile/app/components/QRModal.tsx
@@ -1,22 +1,13 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  View,
-  Text,
-  TextInput,
-  TouchableOpacity,
-  Animated,
-  Dimensions,
+  Modal,
   Pressable,
-  BackHandler,
+  Text,
+  View,
 } from "react-native";
-import PrimaryButton from "./PrimaryButton";
-import { Portal } from "react-native-paper";
-import { CameraView, useCameraPermissions } from "expo-camera";
 import SvgIcon from "./SvgIcon";
-import { useFocusEffect } from "expo-router";
-
-const { height } = Dimensions.get("window");
+import { CameraView, useCameraPermissions } from "expo-camera";
 
 interface OtpModalProps {
   visible: boolean;
@@ -27,112 +18,65 @@ const QRModal: React.FC<OtpModalProps> = ({ visible, onClose }) => {
   const { t } = useTranslation();
   const [permission, requestPermission] = useCameraPermissions();
 
-  const [data, setData] = useState("");
-  const [error, setError] = useState<string | null>(null);
-
-  const translateY = useRef(new Animated.Value(height)).current;
-
-  useEffect(() => {
-    if (visible) {
-      Animated.timing(translateY, {
-        toValue: 0,
-        duration: 300,
-        useNativeDriver: true,
-      }).start();
-    } else {
-      Animated.timing(translateY, {
-        toValue: height,
-        duration: 300,
-        useNativeDriver: true,
-      }).start(() => {
-        setData("");
-        setError(null);
-      });
-    }
-  }, [visible]);
-
-  if (!visible) return null;
-
   return (
-    <Portal>
-      <View className="absolute top-0 bottom-0 left-0 right-0 bg-[rgba(31,31,31,0.5)] z-50">
-        <Animated.View
-          style={{
-            transform: [{ translateY }],
-          }}
-          className="flex-1 bg-black-1000 px-4 justify-center mt-10"
-        >
-          {!permission ? (
-            <View />
-          ) : !permission.granted ? (
-            <View className="flex-1 justify-center items-center px-4">
-              <Text className="text-center mb-4 text-white text-xl">
-                {t("components.camera_permission_required")}
+    <Modal
+      visible={visible}
+      transparent={false}
+      animationType="slide"
+      onRequestClose={() => onClose(null)}
+      statusBarTranslucent
+    >
+      <View className="flex-1 bg-black-1000">
+        {!permission ? (
+          <View />
+        ) : !permission.granted ? (
+          <View className="flex-1 justify-center items-center px-4">
+            <Text className="text-center mb-4 text-white text-xl">
+              {t("components.camera_permission_required")}
+            </Text>
+            <Pressable
+              onPress={requestPermission}
+              className="bg-blue-600 px-6 py-3 rounded mt-2"
+            >
+              <Text className="text-white text-center font-semibold">
+                {t("components.grant_permission")}
               </Text>
+            </Pressable>
+          </View>
+        ) : (
+          <View className="flex-1 bg-black-1000 px-4 pt-14 pb-10">
+            <View className="items-center relative">
               <Pressable
-                onPress={requestPermission}
-                className="bg-blue-600 px-6 py-3 rounded mt-2"
+                onPress={() => onClose(null)}
+                className="absolute left-0 top-0 z-10 p-2"
               >
-                <Text className="text-white text-center font-semibold">
-                  {t("components.grant_permission")}
-                </Text>
+                <SvgIcon name="leftArrow" width="22" height="22" />
               </Pressable>
+              <Text className="text-lg font-semibold text-white">
+                {t("components.qr_scanner")}
+              </Text>
             </View>
-          ) : (
-            <View className="bg-black-1000">
-              <View className="w-full h-full flex">
-                <View className="w-full h-full max-w-5xl mx-auto  pt-8 pb-10">
-                  <View className="w-full">
-                    <View className="items-center relative">
-                      <Pressable
-                        onPress={() => {
-                          onClose(null);
-                        }}
-                        className="absolute left-0 top-0 z-10 p-2"
-                      >
-                        <SvgIcon name="leftArrow" width="22" height="22" />
-                      </Pressable>
-                      <Text className="text-lg font-semibold text-white">
-                        {t("components.qr_scanner")}
-                      </Text>
-                    </View>
-                    <View className="relative mt-10">
-                      <View className="items-center mt-[18px]">
-                        <View>
-                          <CameraView
-                            style={{
-                              height: 300,
-                              width: 300,
-                            }}
-                            onBarcodeScanned={(result) => {
-                              onClose(result.data);
-                            }}
-                          ></CameraView>
-                          <View className="absolute left-0 right-0 top-0 bottom-0 h-full justify-center items-center">
-                            <SvgIcon
-                              name="qrScannerIcon"
-                              width="240"
-                              height="240"
-                            />
-                          </View>
-                        </View>
-
-                        <Text className="mt-10 text-[21px] font-semibold text-white mb-2.5">
-                          {t("components.qr_code")}
-                        </Text>
-                        <Text className="text-[17px] font-normal leading-5 text-gray-1000">
-                          {t("components.scan_qr_instruction")}
-                        </Text>
-                      </View>
-                    </View>
-                  </View>
+            <View className="items-center mt-10">
+              <View>
+                <CameraView
+                  style={{ height: 300, width: 300 }}
+                  onBarcodeScanned={(result) => onClose(result.data)}
+                />
+                <View className="absolute left-0 right-0 top-0 bottom-0 h-full justify-center items-center">
+                  <SvgIcon name="qrScannerIcon" width="240" height="240" />
                 </View>
               </View>
+              <Text className="mt-10 text-[21px] font-semibold text-white mb-2.5">
+                {t("components.qr_code")}
+              </Text>
+              <Text className="text-[17px] font-normal leading-5 text-gray-1000">
+                {t("components.scan_qr_instruction")}
+              </Text>
             </View>
-          )}
-        </Animated.View>
+          </View>
+        )}
       </View>
-    </Portal>
+    </Modal>
   );
 };
 

--- a/mobile/app/components/StakingItem.tsx
+++ b/mobile/app/components/StakingItem.tsx
@@ -75,17 +75,13 @@ const StakingItem: React.FC<Props> = ({
       {item.state === "proceeding" && (
         <TouchableOpacity
           onPress={() => handleEarlyUnstake(item.id)}
-          // Keep only layout/positioning styles here
-          className="mt-4 w-28 rounded-2xl mx-auto overflow-hidden" // Removed rounded-xl and bg-white
+          className="mt-4 w-28 rounded-2xl mx-auto overflow-hidden"
         >
           <LinearGradient
-            // Colors matching the gray gradient
             colors={["#A0A0A0", "#808080", "#606060"]}
-            // Start and end points for a horizontal gradient
-            start={[0, 0]} // x:0, y:0 (top-left)
-            end={[1, 0]} // x:1, y:0 (top-right)
-            // Apply all visual styles including rounded corners, padding, and alignment
-            className="rounded-2xl py-2 items-center justify-center" // Added w-full h-full to fill parent
+            start={[0, 0]}
+            end={[1, 0]}
+            style={{ paddingVertical: 8, borderRadius: 16, alignItems: "center", justifyContent: "center" }}
           >
             <Text className="text-black font-bold text-base">
               {t("staking.unstake")}

--- a/mobile/app/components/ToastOverLay.tsx
+++ b/mobile/app/components/ToastOverLay.tsx
@@ -1,13 +1,11 @@
-// components/ToastOverlay.tsx
 import React, { useEffect, useRef } from "react";
-import { View, Text, Animated } from "react-native";
-import { Portal } from "react-native-paper";
+import { Animated, Modal, Text, View } from "react-native";
 
 interface Props {
   visible: boolean;
   type?: "success" | "error";
   message: string;
-  duration?: number; // auto hide duration in ms
+  duration?: number;
   onHide?: () => void;
 }
 
@@ -18,35 +16,19 @@ const ToastOverlay: React.FC<Props> = ({
   duration = 2000,
   onHide,
 }) => {
-  const translateY = useRef(new Animated.Value(-50)).current;
-  const opacityAnim = useRef(new Animated.Value(0)).current;
+  const translateY = useRef(new Animated.Value(-60)).current;
 
   useEffect(() => {
     if (visible) {
-      // Animate in
-      Animated.parallel([
-        Animated.spring(translateY, { toValue: 0, useNativeDriver: true }),
-        Animated.timing(opacityAnim, {
-          toValue: 1,
-          duration: 200,
-          useNativeDriver: true,
-        }),
-      ]).start();
+      translateY.setValue(-60);
+      Animated.spring(translateY, { toValue: 0, useNativeDriver: true, bounciness: 6 }).start();
 
-      // Auto hide
       const timer = setTimeout(() => {
-        Animated.parallel([
-          Animated.timing(opacityAnim, {
-            toValue: 0,
-            duration: 200,
-            useNativeDriver: true,
-          }),
-          Animated.timing(translateY, {
-            toValue: -50,
-            duration: 200,
-            useNativeDriver: true,
-          }),
-        ]).start(() => onHide && onHide());
+        Animated.timing(translateY, {
+          toValue: -60,
+          duration: 250,
+          useNativeDriver: true,
+        }).start(() => onHide && onHide());
       }, duration);
 
       return () => clearTimeout(timer);
@@ -56,21 +38,28 @@ const ToastOverlay: React.FC<Props> = ({
   if (!visible) return null;
 
   return (
-    <Portal>
-      <Animated.View
-        style={{
-          transform: [{ translateY }],
-          opacity: opacityAnim,
-        }}
-        className={`absolute top-16 left-1/2 -translate-x-1/2 z-50 px-6 py-4 rounded-lg shadow-lg ${
-          type === "success" ? "bg-green-600" : "bg-red-600"
-        }`}
-      >
-        <Text className="text-white text-center font-MetropolisMedium">
-          {message}
-        </Text>
-      </Animated.View>
-    </Portal>
+    <Modal
+      visible={visible}
+      transparent
+      animationType="none"
+      statusBarTranslucent
+    >
+      <View className="flex-1 items-start justify-start pt-16 px-4">
+        <Animated.View
+          style={{
+            transform: [{ translateY }],
+            alignSelf: "center",
+          }}
+          className={`px-6 py-4 rounded-lg shadow-lg ${
+            type === "success" ? "bg-green-600" : "bg-red-600"
+          }`}
+        >
+          <Text className="text-white text-center font-MetropolisMedium">
+            {message}
+          </Text>
+        </Animated.View>
+      </View>
+    </Modal>
   );
 };
 

--- a/mobile/app/components/popup/InfoOverLay.tsx
+++ b/mobile/app/components/popup/InfoOverLay.tsx
@@ -1,95 +1,84 @@
 import React, { useEffect, useMemo, useRef } from "react";
-import { View, Text, Animated, Keyboard } from "react-native";
+import { Animated, Keyboard, Modal, Text, View } from "react-native";
 import PrimaryButton from "../PrimaryButton";
-import { Portal } from "react-native-paper";
 import { useSelector, useDispatch } from "react-redux";
 import { RootState } from "@/src/store";
 import { useTranslation } from "react-i18next";
 import SvgIcon from "../SvgIcon";
-
 import { hideInfo } from "@/src/features/infoOverLaySlice";
 
 const InfoOverlay = () => {
-    const dispatch = useDispatch();
-    const { visible, type, message } = useSelector(
-        (state: RootState) => state.popup
-    );
+  const dispatch = useDispatch();
+  const { visible, type, message } = useSelector(
+    (state: RootState) => state.popup
+  );
 
-    const scaleAnim = useRef(new Animated.Value(0.8)).current;
-    const opacityAnim = useRef(new Animated.Value(0)).current;
-    const { t } = useTranslation();
+  const scaleAnim = useRef(new Animated.Value(0.95)).current;
+  const { t } = useTranslation();
 
-    const iconName = useMemo(() => {
-        switch (type) {
-            case "success":
-                return "successIcon";
-            case "error":
-                return "errorIcon";
-            default:
-                return "infoIcon";
-        }
-    }, [type]);
+  const iconName = useMemo(() => {
+    switch (type) {
+      case "success":
+        return "successIcon";
+      case "error":
+        return "errorIcon";
+      default:
+        return "infoIcon";
+    }
+  }, [type]);
 
-    const colorClass = useMemo(() => {
-        switch (type) {
-            case "success":
-                return "text-green-400";
-            case "error":
-                return "text-red-400";
-            default:
-                return "text-blue-400";
-        }
-    }, [type]);
+  const colorClass = useMemo(() => {
+    switch (type) {
+      case "success":
+        return "text-green-400";
+      case "error":
+        return "text-red-400";
+      default:
+        return "text-blue-400";
+    }
+  }, [type]);
 
-    const displayText = message || t("common.info");
+  const displayText = message || t("common.info");
 
-    useEffect(() => {
-        if (visible) {
-            Keyboard.dismiss();
-        }
-    }, [visible]);
+  useEffect(() => {
+    if (visible) {
+      Keyboard.dismiss();
+      scaleAnim.setValue(0.95);
+      Animated.spring(scaleAnim, { toValue: 1, useNativeDriver: true, bounciness: 4 }).start();
+    } else {
+      scaleAnim.setValue(0.95);
+    }
+  }, [visible]);
 
-    useEffect(() => {
-        if (visible) {
-            Animated.parallel([
-                Animated.spring(scaleAnim, {
-                    toValue: 1,
-                    useNativeDriver: true,
-                }),
-                Animated.timing(opacityAnim, {
-                    toValue: 1,
-                    duration: 200,
-                    useNativeDriver: true,
-                }),
-            ]).start();
-        } else {
-            scaleAnim.setValue(0.8);
-            opacityAnim.setValue(0);
-        }
-    }, [visible]);
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={() => dispatch(hideInfo())}
+      statusBarTranslucent
+    >
+      <View
+        className="flex-1 items-center justify-center"
+        style={{ backgroundColor: "rgba(31,31,31,0.55)" }}
+      >
+        <Animated.View
+          style={{ transform: [{ scale: scaleAnim }] }}
+          className="bg-[#191919] rounded-[16px] px-6 py-8 w-[82%] items-center"
+        >
+          <Text className={`text-white text-center text-lg mt-4 ${colorClass}`}>
+            {displayText}
+          </Text>
 
-    if (!visible) return null;
-
-    return (
-        <Portal>
-            <View className="flex-1 items-center justify-center bg-[rgba(31,31,31,0.55)] absolute top-0 bottom-0 left-0 right-0 z-50">
-                <Animated.View
-                    style={{ transform: [{ scale: scaleAnim }], opacity: opacityAnim }}
-                    className="bg-[#191919] rounded-[16px] px-6 py-8 w-[82%] items-center"
-                >
-                    <Text className={`text-white text-center text-lg mt-4 ${colorClass}`}>
-                        {displayText}
-                    </Text>
-
-                    <PrimaryButton
-                        text="OK"
-                        onPress={() => dispatch(hideInfo())}
-                        className="mt-6"
-                    />
-                </Animated.View>
-            </View>
-        </Portal>
-    );
+          <PrimaryButton
+            text="OK"
+            onPress={() => dispatch(hideInfo())}
+            className="mt-6"
+          />
+        </Animated.View>
+      </View>
+    </Modal>
+  );
 };
 
 export default InfoOverlay;

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mecca-native",
-  "version": "1.0.44",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mecca-native",
-      "version": "1.0.44",
+      "version": "1.1.0",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@fortawesome/free-solid-svg-icons": "^7.1.0",
@@ -72,7 +72,7 @@
         "react-native-css-interop": "^0.1.22",
         "react-native-gesture-handler": "~2.31.1",
         "react-native-get-random-values": "~1.11.0",
-        "react-native-gifted-charts": "^1.4.61",
+        "react-native-gifted-charts": "^1.4.77",
         "react-native-graph": "^1.1.0",
         "react-native-modal": "^14.0.0-rc.1",
         "react-native-paper": "^5.14.5",
@@ -12370,9 +12370,10 @@
       }
     },
     "node_modules/gifted-charts-core": {
-      "version": "0.1.63",
-      "resolved": "https://registry.npmjs.org/gifted-charts-core/-/gifted-charts-core-0.1.63.tgz",
-      "integrity": "sha512-e5sJwI2RIcdnJ4p4ozUHfpbVUXyHn2CJj2h8BpmeugjgF7k7KvL0QI22M4pVQIIIRei3exjEhv8HwXaFtAx/dA==",
+      "version": "0.1.81",
+      "resolved": "https://registry.npmjs.org/gifted-charts-core/-/gifted-charts-core-0.1.81.tgz",
+      "integrity": "sha512-plgJSbKB0Lxp2KQ/Fvj1qbOhiy6wxPiZ0Av60iFHpSSu6YlJjYhwczx5w2/iJQdZYb851OFMHgN/pgTNVLv6dA==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "*",
         "react-native": "*",
@@ -17179,11 +17180,12 @@
       }
     },
     "node_modules/react-native-gifted-charts": {
-      "version": "1.4.61",
-      "resolved": "https://registry.npmjs.org/react-native-gifted-charts/-/react-native-gifted-charts-1.4.61.tgz",
-      "integrity": "sha512-UCNZDntpvqJV0x8iBhx9fMTjFLUb3PI3V77Wni10HFJgMwM6SA3Xg/VpkRmIGT4r4PRWGcsFTInyR3eu8XYuTQ==",
+      "version": "1.4.77",
+      "resolved": "https://registry.npmjs.org/react-native-gifted-charts/-/react-native-gifted-charts-1.4.77.tgz",
+      "integrity": "sha512-Ul4juHO0Gicng139i61AzQ3h4kLM25dzid1rU+d3d7PuHsI4UypgeChz/luaHMZaWgXkALjq6DLqaM2Y2AEhrA==",
+      "license": "MIT",
       "dependencies": {
-        "gifted-charts-core": "0.1.63"
+        "gifted-charts-core": "0.1.81"
       },
       "peerDependencies": {
         "expo-linear-gradient": "*",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mecca-native",
   "main": "expo-router/entry",
-  "version": "1.0.44",
+  "version": "1.1.0",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",
@@ -79,7 +79,7 @@
     "react-native-css-interop": "^0.1.22",
     "react-native-gesture-handler": "~2.31.1",
     "react-native-get-random-values": "~1.11.0",
-    "react-native-gifted-charts": "^1.4.61",
+    "react-native-gifted-charts": "^1.4.77",
     "react-native-graph": "^1.1.0",
     "react-native-modal": "^14.0.0-rc.1",
     "react-native-paper": "^5.14.5",

--- a/mobile/src/api/kycApi.ts
+++ b/mobile/src/api/kycApi.ts
@@ -1,0 +1,114 @@
+import { createApi, BaseQueryFn } from "@reduxjs/toolkit/query/react";
+import { Platform } from "react-native";
+import { apiBaseUrl, apiKey } from "@/lib/constants";
+import storage from "@/storage";
+import { STORAGE_KEYS } from "@/storage/keys";
+import logger from "@/lib/logger";
+import {
+  KycInfoResponse,
+  KycReadySaveResponse,
+  KycStartResponse,
+  KycPollResponse,
+} from "@/src/api/types/kyc";
+
+const log = logger.child({ module: "kycApi" });
+
+const kycBaseQuery: BaseQueryFn<
+  { path: string; body?: Record<string, string> },
+  unknown,
+  string
+> = async ({ path, body = {} }) => {
+  const url = `${apiBaseUrl}${path}`;
+
+  try {
+    const token = await storage.retreive(STORAGE_KEYS.AUTH.TOKEN);
+
+    const params = new URLSearchParams();
+    Object.entries({ ...body, apikey: apiKey }).forEach(([k, v]) => params.append(k, v));
+
+    // log after params built; omit apikey from log
+    log.debug({ url, body }, "kyc request");
+
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Authorization: `Bearer ${token ?? ""}`,
+      },
+      body: params.toString(),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      const error = (data?.status as string) ?? "server_error";
+      log.warn({ url, status: response.status, error, payload: data }, "kyc response error");
+      return { error };
+    }
+
+    if (typeof data === "string") {
+      log.warn({ url, error: data }, "kyc server error string");
+      return { error: data };
+    }
+
+    log.debug({ url, data }, "kyc response ok");
+    return { data };
+  } catch (e: any) {
+    const error = e?.message ?? "network_error";
+    log.error({ url, error }, "kyc request failed");
+    return { error };
+  }
+};
+
+export const kycApi = createApi({
+  reducerPath: "kycApi",
+  baseQuery: kycBaseQuery,
+  endpoints: (builder) => ({
+    getKycInfo: builder.mutation<KycInfoResponse, void>({
+      query: () => ({ path: "/api/app-kyc/info" }),
+    }),
+
+    readySave: builder.mutation<
+      KycReadySaveResponse,
+      { mt_name: string; mt_birth: string }
+    >({
+      query: (args) => ({
+        path: "/api/app-kyc/ready-save",
+        body: args,
+      }),
+    }),
+
+    startKyc: builder.mutation<KycStartResponse, { document_type: string }>({
+      query: (args) => ({
+        path: "/api/app-kyc/start",
+        body: {
+          document_type: args.document_type,
+          platform: Platform.OS,
+          app_callback_uri: "pingwallet://app-kyc-return",
+        },
+      }),
+      async onQueryStarted(_, { queryFulfilled }) {
+        try {
+          const { data } = await queryFulfilled;
+          await storage.save(STORAGE_KEYS.KYC.SESSION_ID, data.session_id);
+        } catch {
+          // session_id not saved — screen must fall back to deep link param
+        }
+      },
+    }),
+
+    pollKyc: builder.mutation<KycPollResponse, { session_id: string }>({
+      query: (args) => ({
+        path: "/api/app-kyc/poll",
+        body: args,
+      }),
+    }),
+  }),
+});
+
+export const {
+  useGetKycInfoMutation,
+  useReadySaveMutation,
+  useStartKycMutation,
+  usePollKycMutation,
+} = kycApi;


### PR DESCRIPTION
## Summary

- **Portal → Modal migration**: Replaced all `react-native-paper` Portal usages with RN built-in `Modal`. Portal touch events are broken on New Architecture (Fabric) — buttons inside Portal overlays were unresponsive
- **opacityAnim race condition fix**: Removed `Animated.Value(0)` + `useEffect` opacity pattern across all modal components (InfoAlert, LoadingOverlay, InfoOverlay, BalanceYieldGuide, InfoPopup, DialogAlert, ToastOverlay). Backdrop showed but content stayed invisible. Fixed with `Modal animationType="fade"` (OS-level) + scale spring only
- **Modal-outside-ScrollView**: Moved modal JSX outside `<ScrollView>` in 8 screens — nesting Modal inside ScrollView clips/hides content on Android Fabric
- **google-otp crash fix**: Guard `<QRCode>` against empty `qrUrl` when user is already registered (`Error: No input text` crash)
- **chart-view layout fix**: Remove `flex-1` from ActionButton inner View causing send/receive button overflow on page open
- **Validation fixes**: NaN guard for `parseFloat(undefined)` in deposit screen, hide KYC note when `kycCompleted`, try/catch for Decimal ops in withdrawal
- **Package fixes**: `react-native-qrcode-styled` → `react-native-qrcode-svg`, removed `react-native-toast-message`, upgraded `gifted-charts` 1.4.61→1.4.77
- **Version bump**: 1.0.44 → 1.1.0

## Test plan

- [ ] Withdrawal/deposit → Next with invalid input → InfoAlert dialog visible and OK button pressable
- [ ] Home "?" button → BalanceYieldGuide dialog visible and dismissable
- [ ] Settings → Google OTP → no crash when user is already registered
- [ ] Settings → Change password → OTP modal slides up and is interactable
- [ ] Chart-view → send/receive buttons render without overflow on open
- [ ] Loading spinner visible during API calls
- [ ] Toast notifications slide in from top correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)