### PR TITLE
ci: add EAS deploy workflows (deploy, deploy_android, deploy_ios)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,21 @@
+name: Deploy
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - release
+      - release/*
+    paths:
+      - mobile/**
+
+jobs:
+  android:
+    name: Deploy Android
+    uses: ./.github/workflows/deploy_android.yml
+    secrets: inherit
+
+  ios:
+    name: Deploy iOS
+    uses: ./.github/workflows/deploy_ios.yml
+    secrets: inherit

--- a/.github/workflows/deploy_android.yml
+++ b/.github/workflows/deploy_android.yml
@@ -1,0 +1,44 @@
+name: Deploy Android
+
+on:
+  workflow_dispatch: {}
+  workflow_call: {}
+  push:
+    branches:
+      - release
+      - release/*
+    paths:
+      - mobile/**
+
+jobs:
+  build-android:
+    name: EAS Build (Android)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mobile
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: mobile/package-lock.json
+
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Android (production)
+        run: eas build --platform android --profile production --non-interactive
+
+      - name: Submit to Play Store
+        run: eas submit --platform android --latest --non-interactive
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}

--- a/.github/workflows/deploy_ios.yml
+++ b/.github/workflows/deploy_ios.yml
@@ -1,0 +1,44 @@
+name: Deploy iOS
+
+on:
+  workflow_dispatch: {}
+  workflow_call: {}
+  push:
+    branches:
+      - release
+      - release/*
+    paths:
+      - mobile/**
+
+jobs:
+  build-ios:
+    name: EAS Build (iOS)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mobile
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: mobile/package-lock.json
+
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build iOS (production)
+        run: eas build --platform ios --profile production --non-interactive
+
+      - name: Submit to App Store
+        run: eas submit --platform ios --latest --non-interactive
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}


### PR DESCRIPTION
## Summary

Adds three EAS (Expo Application Services) GitHub Actions workflows for automated production builds and store submissions.

### Workflows

| File | Trigger | Does |
|------|---------|------|
| `deploy.yml` | push to `release`/`release/*` + `workflow_dispatch` | Fans out to both Android and iOS jobs in parallel |
| `deploy_android.yml` | push to `release`/`release/*` + `workflow_dispatch` + `workflow_call` | EAS production build → Play Store submit |
| `deploy_ios.yml` | push to `release`/`release/*` + `workflow_dispatch` + `workflow_call` | EAS production build → App Store submit |

### How it works
- `deploy.yml` uses `workflow_call` to reuse `deploy_android.yml` and `deploy_ios.yml` — both platforms build in parallel
- Each individual workflow can also be triggered manually (`workflow_dispatch`) for platform-specific reruns
- `paths: mobile/**` prevents spurious runs when only CI config or docs change
- Uses `expo/expo-github-action@v8` with `eas-version: latest`

### Required secret
`EXPO_TOKEN` must be set in repo Settings → Secrets → Actions.  
Generate at: https://expo.dev/accounts/[account]/settings/access-tokens

## Test plan
- [ ] Confirm `EXPO_TOKEN` secret is set in repo settings
- [ ] Push a test commit to `release` branch and verify all three workflows trigger
- [ ] Manually trigger `deploy_android` and `deploy_ios` via Actions tab to test independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)