### PR TITLE
ci(eas): remove push triggers from deploy_android and deploy_ios

### DIFF
--- a/mobile/.eas/workflows/deploy_android.yml
+++ b/mobile/.eas/workflows/deploy_android.yml
@@ -2,11 +2,6 @@ name: Deploy Android
 
 "on":
   workflow_dispatch: {}
-  push:
-    branches:
-      - release
-    paths:
-      - mobile/**
 
 jobs:
   build_android:

--- a/mobile/.eas/workflows/deploy_ios.yml
+++ b/mobile/.eas/workflows/deploy_ios.yml
@@ -2,11 +2,6 @@ name: Deploy iOS
 
 "on":
   workflow_dispatch: {}
-  push:
-    branches:
-      - release
-    paths:
-      - mobile/**
 
 jobs:
   build_ios:


### PR DESCRIPTION
## Summary
- Removes `on: push` from `.eas/workflows/deploy_android.yml` and `.eas/workflows/deploy_ios.yml`
- `deploy.yml` already handles the push trigger and fans both out — having it in the sub-workflows causes duplicate builds on every release branch push

🤖 Generated with [Claude Code](https://claude.com/claude-code)