### PR TITLE
fix(withdrawal): calculate KYC threshold in USD using token price

### DIFF
--- a/mobile/app/(Views)/confirm-withdrawl.tsx
+++ b/mobile/app/(Views)/confirm-withdrawl.tsx
@@ -48,6 +48,7 @@ const ConfirmWithdraw = () => {
     {},
   );
   const [withdrawlSuccess, setWithdrawlSuccess] = useState(false);
+  const [kycRequired, setKycRequired] = useState(false);
   const dispatch = useDispatch();
 
   const processWithdraw = async () => {
@@ -84,6 +85,17 @@ const ConfirmWithdraw = () => {
       WithdrawFee: withdrawFees,
     });
     dispatch(hideLoading());
+
+    if (result === "kyc_required") {
+      setInfoAlertState({
+        type: "info",
+        text: t("withdrawal.kyc_required_to_withdraw"),
+        primaryButtonText: t("kyc.verify_now") ?? "Verify Now",
+      });
+      setKycRequired(true);
+      setInfoAlertVisible(true);
+      return;
+    }
 
     if (typeof result === "string") {
       setInfoAlertState({
@@ -224,6 +236,10 @@ const ConfirmWithdraw = () => {
           visible={infoAlertVisible}
           setVisible={setInfoAlertVisible}
           onDismiss={() => {
+            if (kycRequired) {
+              router.replace("/(Views)/kyc/ready");
+              return;
+            }
             if (withdrawlSuccess) {
               if (router.canDismiss()) {
                 router.dismissAll();

--- a/mobile/app/(Views)/withdrawal-view.tsx
+++ b/mobile/app/(Views)/withdrawal-view.tsx
@@ -51,6 +51,7 @@ const WithDrawal = () => {
   const minWithdrawl = useSelector(
     (state: RootState) => state.token.minWithdraw[symbol]
   );
+  const quotes = useSelector((state: RootState) => state.token.quotes || {});
 
   const dispatch = useDispatch();
 
@@ -157,10 +158,9 @@ const WithDrawal = () => {
         return;
       }
 
-      if (
-        amount.greaterThanOrEqualTo(KYC_REQUIRED_THRESHOLD) &&
-        !kycCompleted
-      ) {
+      const tokenPrice = new Decimal((quotes as any)[symbol] ?? 0);
+      const usdValue = amount.mul(tokenPrice);
+      if (usdValue.greaterThanOrEqualTo(KYC_REQUIRED_THRESHOLD) && !kycCompleted) {
         router.replace("/(Views)/kyc/ready");
         return;
       }


### PR DESCRIPTION
## Summary

- **Frontend USD threshold**: `withdrawal-view.tsx` now reads the token's market price from Redux `state.token.quotes[symbol]` and multiplies it by the withdrawal amount to compute a USD value. That USD value is compared against the \$1000 threshold instead of the raw token amount, so e.g. withdrawing 0.5 BTC at \$2500/BTC correctly triggers the KYC gate.
- **Consistent with existing pattern**: The quotes selector is already used in `home.tsx` (`new Decimal(quotes[token]).mul(balance)`); this change follows the same pattern in the withdrawal flow.
- **Backend `kyc_required` response**: `confirm-withdrawl.tsx` now detects when the backend returns the string `"kyc_required"` and, instead of showing a generic error, shows an info-type alert with a "Verify Now" button. On dismiss the user is redirected to `/(Views)/kyc/ready`.

## Test plan

- [ ] Withdraw a token whose USD value is below \$1000 — should proceed to confirm screen without KYC redirect
- [ ] Withdraw a token whose USD value is >= \$1000 with KYC not completed — should redirect to KYC ready page immediately in `withdrawal-view`
- [ ] Simulate backend returning `"kyc_required"` from the withdraw API — confirm-withdrawl should show the KYC info alert and redirect on dismiss
- [ ] Confirm existing success flow (redirect to asset history) still works after a successful withdrawal
- [ ] Confirm the yellow KYC warning banner still appears for non-KYC users

🤖 Generated with [Claude Code](https://claude.com/claude-code)