### PR TITLE
chore(release): merge main → preview (1.2.0)

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Ping Wallet",
     "slug": "mecca",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "orientation": "portrait",
     "icon": "./assets/images/app_icon.png",
     "scheme": [

--- a/mobile/app/(Tabs)/home.tsx
+++ b/mobile/app/(Tabs)/home.tsx
@@ -363,8 +363,8 @@ export default function HomeScreen() {
                 <TouchableOpacity
                   key={token}
                   className="flex flex-col border-2 mb-2 border-black-1200 bg-black-1200 rounded-2xl"
-                  disabled={token === "usdt_savings"}
-                  onPress={() => {
+                  activeOpacity={token === "usdt_savings" ? 1 : 0.7}
+                  onPress={token === "usdt_savings" ? undefined : () => {
                     router.navigate({
                       pathname: "/(Views)/chart-view",
                       params: {

--- a/mobile/app/(Tabs)/home.tsx
+++ b/mobile/app/(Tabs)/home.tsx
@@ -38,6 +38,7 @@ import { requestNotificationPermission } from "@/lib/notifications/requestPermis
 import ReceiveInstant from "../components/earn/ReceiveInstant";
 import BalanceYieldGuide from "../components/BalanceYieldGuide";
 import LabelBadge from "../components/LabelBadge";
+import AppText from "../components/AppText";
 import useSetting from "@/hooks/api/useSetting";
 import LoanIcon from "@/assets/images/hand-dollar.svg";
 import { setSettings } from "@/src/features/settings/settingsSlice";
@@ -250,13 +251,16 @@ export default function HomeScreen() {
                   onPress={() => setShowEditProfile(true)}
                   className="max-w-full"
                 >
-                  <Text
+                  <AppText
+                    loading={!email}
+                    shimmerWidth={180}
+                    shimmerHeight={28}
                     numberOfLines={1}
                     ellipsizeMode="tail"
                     className="text-[22px] text-white font-medium tracking-[-0.44px]"
                   >
                     {email}
-                  </Text>
+                  </AppText>
                 </Pressable>
                 <LabelBadge
                   loading={!kycFetched}

--- a/mobile/app/(Views)/confirm-withdrawl.tsx
+++ b/mobile/app/(Views)/confirm-withdrawl.tsx
@@ -48,6 +48,7 @@ const ConfirmWithdraw = () => {
     {},
   );
   const [withdrawlSuccess, setWithdrawlSuccess] = useState(false);
+  const [kycRequired, setKycRequired] = useState(false);
   const dispatch = useDispatch();
 
   const processWithdraw = async () => {
@@ -84,6 +85,17 @@ const ConfirmWithdraw = () => {
       WithdrawFee: withdrawFees,
     });
     dispatch(hideLoading());
+
+    if (result === "kyc_required") {
+      setInfoAlertState({
+        type: "info",
+        text: t("withdrawal.kyc_required_to_withdraw"),
+        primaryButtonText: t("kyc.verify_now") ?? "Verify Now",
+      });
+      setKycRequired(true);
+      setInfoAlertVisible(true);
+      return;
+    }
 
     if (typeof result === "string") {
       setInfoAlertState({
@@ -224,6 +236,10 @@ const ConfirmWithdraw = () => {
           visible={infoAlertVisible}
           setVisible={setInfoAlertVisible}
           onDismiss={() => {
+            if (kycRequired) {
+              router.replace("/(Views)/kyc/ready");
+              return;
+            }
             if (withdrawlSuccess) {
               if (router.canDismiss()) {
                 router.dismissAll();

--- a/mobile/app/(Views)/withdrawal-view.tsx
+++ b/mobile/app/(Views)/withdrawal-view.tsx
@@ -1,10 +1,8 @@
 import { router, useLocalSearchParams, useNavigation } from "expo-router";
 import React, { useEffect, useMemo, useState } from "react";
 import {
-  Image,
   KeyboardAvoidingView,
   Platform,
-  Pressable,
   ScrollView,
   Text,
   TextInput,
@@ -17,14 +15,9 @@ import PrimaryButton from "../components/PrimaryButton";
 import QRModal from "../components/QRModal";
 import InfoAlert, { InfoAlertProps } from "../components/InfoAlert";
 import { isValidPublicKey } from "@/utils/web3";
-import { useAppDispatch } from "@/src/store/hooks";
 import { RootState } from "@/src/store";
 import { useSelector } from "react-redux";
-import { RootState as RS } from "@/src/store";
-import useAsset from "@/hooks/api/useAsset";
 import useUser from "@/hooks/api/useUser";
-import useKyc from "@/hooks/api/useKyc";
-import { setKycCompleted, setKycFetched } from "@/src/features/user/userSlice";
 import {
   setMinWithdraw,
   setWithdrawFees,
@@ -39,11 +32,8 @@ import {
   setLockupBalances,
 } from "@/src/features/balance/balanceSlice";
 
-const KYC_REQUIRED_THRESHOLD = 1000;
-
 const WithDrawal = () => {
   const navigation = useNavigation();
-  const kycCompleted = useSelector((state: RS) => state.user.kycCompleted);
   const { symbol } = useLocalSearchParams<{ symbol: keyof TokenBalances }>();
   const freeBalance = useSelector(
     (state: RootState) => state.balance.free[symbol]
@@ -51,7 +41,6 @@ const WithDrawal = () => {
   const minWithdrawl = useSelector(
     (state: RootState) => state.token.minWithdraw[symbol]
   );
-  const quotes = useSelector((state: RootState) => state.token.quotes || {});
 
   const dispatch = useDispatch();
 
@@ -158,13 +147,6 @@ const WithDrawal = () => {
         return;
       }
 
-      const tokenPrice = new Decimal((quotes as any)[symbol] ?? 0);
-      const usdValue = amount.mul(tokenPrice);
-      if (usdValue.greaterThanOrEqualTo(KYC_REQUIRED_THRESHOLD) && !kycCompleted) {
-        router.replace("/(Views)/kyc/ready");
-        return;
-      }
-
       router.push({
         pathname: "/confirm-withdrawl",
         params: {
@@ -181,20 +163,7 @@ const WithDrawal = () => {
   useEffect(() => {
     syncData();
     syncBalance();
-    checkKyc();
   }, []);
-
-  const checkKyc = async () => {
-    try {
-      const res = await useKyc.getKycInfo();
-      if (typeof res !== "string") {
-        dispatch(setKycCompleted(res.kyc_yn === "Y"));
-        dispatch(setKycFetched(true));
-      }
-    } catch {
-      // silent — do not block page load if KYC check fails
-    }
-  };
 
   return (
     <View className="bg-black-1000 h-full">
@@ -307,14 +276,6 @@ const WithDrawal = () => {
                   </View>
                 </View>
               </View>
-
-              {!kycCompleted && (
-                <View className="mx-1 mb-3 px-4 py-3 rounded-[12px] bg-yellow-500/10 border border-yellow-500/30">
-                  <Text className="text-yellow-400 text-sm text-center">
-                    {t("withdrawal.kyc_required_above")}
-                  </Text>
-                </View>
-              )}
 
               <PrimaryButton text={t("withdrawal.next")} onPress={handleNext} />
             </View>

--- a/mobile/app/(Views)/withdrawal-view.tsx
+++ b/mobile/app/(Views)/withdrawal-view.tsx
@@ -51,6 +51,7 @@ const WithDrawal = () => {
   const minWithdrawl = useSelector(
     (state: RootState) => state.token.minWithdraw[symbol]
   );
+  const quotes = useSelector((state: RootState) => state.token.quotes || {});
 
   const dispatch = useDispatch();
 
@@ -157,10 +158,9 @@ const WithDrawal = () => {
         return;
       }
 
-      if (
-        amount.greaterThanOrEqualTo(KYC_REQUIRED_THRESHOLD) &&
-        !kycCompleted
-      ) {
+      const tokenPrice = new Decimal((quotes as any)[symbol] ?? 0);
+      const usdValue = amount.mul(tokenPrice);
+      if (usdValue.greaterThanOrEqualTo(KYC_REQUIRED_THRESHOLD) && !kycCompleted) {
         router.replace("/(Views)/kyc/ready");
         return;
       }

--- a/mobile/app/components/AppText.tsx
+++ b/mobile/app/components/AppText.tsx
@@ -1,0 +1,108 @@
+import React, { useEffect, useRef } from "react";
+import { Animated, Easing, Text, TextProps, View } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+
+interface AppTextProps extends TextProps {
+  /** When true, renders a shimmer placeholder instead of the text. */
+  loading?: boolean;
+  /** Width of the shimmer placeholder. Defaults to 120. */
+  shimmerWidth?: number;
+  /** Height of the shimmer placeholder. Auto-derived from className/style if omitted. */
+  shimmerHeight?: number;
+}
+
+const TAILWIND_SIZES: Record<string, number> = {
+  "text-xs": 12,
+  "text-sm": 14,
+  "text-base": 16,
+  "text-lg": 18,
+  "text-xl": 20,
+  "text-2xl": 24,
+  "text-3xl": 30,
+  "text-4xl": 36,
+  "text-5xl": 48,
+};
+
+function deriveFontSize(className?: string, style?: TextProps["style"]): number {
+  // 1. Try arbitrary value from className e.g. text-[22px] or text-[22]
+  if (className) {
+    const arbitrary = className.match(/text-\[(\d+)(?:px)?\]/);
+    if (arbitrary) return parseInt(arbitrary[1], 10);
+    // 2. Try named Tailwind size
+    for (const [cls, size] of Object.entries(TAILWIND_SIZES)) {
+      if (className.includes(cls)) return size;
+    }
+  }
+  // 3. Try style prop
+  const flat = Array.isArray(style) ? Object.assign({}, ...style) : style ?? {};
+  if ((flat as any)?.fontSize) return (flat as any).fontSize;
+  return 16;
+}
+
+function TextShimmer({ width, height }: { width: number; height: number }) {
+  const progress = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    const anim = Animated.loop(
+      Animated.timing(progress, {
+        toValue: 1,
+        duration: 1100,
+        easing: Easing.linear,
+        useNativeDriver: true,
+      })
+    );
+    anim.start();
+    return () => anim.stop();
+  }, [progress]);
+
+  const translateX = progress.interpolate({
+    inputRange: [0, 1],
+    outputRange: [-width, width],
+  });
+
+  return (
+    <View
+      accessibilityRole="progressbar"
+      className="overflow-hidden rounded-md bg-gray-1500/40"
+      style={{ width, height, borderRadius: height / 2 }}
+    >
+      <Animated.View
+        style={{
+          position: "absolute",
+          top: 0,
+          bottom: 0,
+          width,
+          transform: [{ translateX }],
+        }}
+      >
+        <LinearGradient
+          colors={["transparent", "rgba(255,255,255,0.18)", "transparent"]}
+          start={{ x: 0, y: 0.5 }}
+          end={{ x: 1, y: 0.5 }}
+          style={{ flex: 1 }}
+        />
+      </Animated.View>
+    </View>
+  );
+}
+
+export default function AppText({
+  loading = false,
+  shimmerWidth = 120,
+  shimmerHeight,
+  style,
+  className,
+  children,
+  ...rest
+}: AppTextProps) {
+  if (loading) {
+    const height = shimmerHeight ?? deriveFontSize(className, style);
+    return <TextShimmer width={shimmerWidth} height={height} />;
+  }
+
+  return (
+    <Text style={style} className={className} {...rest}>
+      {children}
+    </Text>
+  );
+}

--- a/mobile/app/components/PrimaryButton.tsx
+++ b/mobile/app/components/PrimaryButton.tsx
@@ -21,17 +21,18 @@ const PrimaryButton = ({
         onPress={onPress}
         onPressIn={() => setPressed(true)}
         onPressOut={() => setPressed(false)}
-        style={{ opacity: pressed && !disabled ? 0.85 : 1, transform: [{ scale: pressed && !disabled ? 0.97 : 1 }] }}
+        style={{
+          opacity: pressed && !disabled ? 0.85 : 1,
+          transform: [{ scale: pressed && !disabled ? 0.97 : 1 }],
+        }}
         className={`
           text-center w-full py-2.5 rounded-[15px]
           flex items-center justify-center
-          ${disabled ? "bg-gray-300 border-gray-300 opacity-50" : "bg-pink-1100 border-pink-1100"}
+          ${disabled ? "bg-gray-600" : "bg-pink-1100"}
           ${className}
         `}
       >
-        <Text
-          className={`text-base font-semibold ${disabled ? "text-gray-300" : "text-white"}`}
-        >
+        <Text className="text-base font-semibold text-white">
           {text}
         </Text>
       </Pressable>

--- a/mobile/locales/en/translation.json
+++ b/mobile/locales/en/translation.json
@@ -246,6 +246,7 @@
     "invalid_amount": "Please enter a valid withdrawal amount.",
     "insufficient_balance": "Insufficient balance. Available: {{balance}} {{symbol}}",
     "kyc_required_above": "Withdrawals of $1,000 or more require KYC verification.",
+    "kyc_required_to_withdraw": "KYC verification is required to process this withdrawal. Please complete identity verification to continue.",
     "next": "NEXT"
   },
   "lockup": {
@@ -351,6 +352,9 @@
     "exchanging_tokens": "Exchanging tokens within the app",
     "not_found": "FAQ not found",
     "update_time": "Update Time"
+  },
+  "kyc": {
+    "verify_now": "Verify Now"
   },
   "common": {
     "yes": "YES",

--- a/mobile/locales/ko/translation.json
+++ b/mobile/locales/ko/translation.json
@@ -246,6 +246,7 @@
     "invalid_amount": "유효한 출금 금액을 입력해주세요.",
     "insufficient_balance": "잔액 부족. 사용 가능: {{balance}} {{symbol}}",
     "kyc_required_above": "$1,000 이상 출금 시 KYC 인증이 필요합니다.",
+    "kyc_required_to_withdraw": "이 출금을 처리하려면 KYC 인증이 필요합니다. 계속하려면 신원 인증을 완료해 주세요.",
     "next": "다음"
   },
   "lockup": {
@@ -351,6 +352,9 @@
     "exchanging_tokens": "앱 내에서 토큰 교환하기",
     "not_found": "자주 묻는 질문을 찾을 수 없습니다.",
     "update_time": "업데이트 시간"
+  },
+  "kyc": {
+    "verify_now": "지금 인증하기"
   },
   "common": {
     "yes": "예",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mecca-native",
   "main": "expo-router/entry",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",


### PR DESCRIPTION
## Summary

Promotes `main` into `preview` for the 1.2.0 release build.

Includes:
- KYC check moved to backend (withdrawal Screen 2)
- USDT token always-pressed fix
- PrimaryButton disabled state fix
- AppText shimmer component
- KYC i18n keys (EN + KO)
- Minor version bump 1.1.1 → 1.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)