### PR TITLE
chore(ci): add version-bump workflow with patch/minor/major dropdown

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,73 @@
+name: Version Bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  bump:
+    name: Bump ${{ inputs.bump }} version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Compute new version
+        id: ver
+        working-directory: mobile
+        run: |
+          OLD=$(node -p "require('./package.json').version")
+          NEW=$(npx --yes semver "$OLD" -i ${{ inputs.bump }})
+          echo "old=$OLD" >> $GITHUB_OUTPUT
+          echo "new=$NEW" >> $GITHUB_OUTPUT
+          echo "branch=chore/bump-${{ inputs.bump }}-$NEW" >> $GITHUB_OUTPUT
+
+      - name: Apply version to package.json and app.json
+        working-directory: mobile
+        run: |
+          NEW=${{ steps.ver.outputs.new }}
+          node -e "
+            const fs = require('fs');
+            ['package.json', 'app.json'].forEach(f => {
+              const raw = fs.readFileSync(f, 'utf8');
+              fs.writeFileSync(f, raw.replace(/\"version\": \"[^\"]+\"/, '\"version\": \"' + process.env.NEW + '\"'));
+            });
+          " NEW=$NEW
+
+      - name: Commit and push branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b ${{ steps.ver.outputs.branch }}
+          git add mobile/package.json mobile/app.json
+          git commit -m "chore(release): bump ${{ inputs.bump }} version ${{ steps.ver.outputs.old }} → ${{ steps.ver.outputs.new }}"
+          git push origin ${{ steps.ver.outputs.branch }}
+
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --title "chore(release): bump ${{ inputs.bump }} version ${{ steps.ver.outputs.old }} → ${{ steps.ver.outputs.new }}" \
+            --body "Automated ${{ inputs.bump }} version bump from \`${{ steps.ver.outputs.old }}\` to \`${{ steps.ver.outputs.new }}\`." \
+            --base main \
+            --head ${{ steps.ver.outputs.branch }}


### PR DESCRIPTION
## Summary
Adds a manually triggered GitHub Actions workflow that bumps the app version and opens a PR automatically.

## Usage
1. Go to **Actions → Version Bump → Run workflow**
2. Select `patch`, `minor`, or `major` from the dropdown
3. The workflow will:
   - Compute the new semver from the current `package.json` version
   - Update `mobile/package.json` and `mobile/app.json`
   - Push a branch `chore/bump-<type>-<new-version>`
   - Open a PR to `main` automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)