### PR TITLE
fix(ci): android deploy sends failure Slack on success

### DIFF
--- a/mobile/.eas/workflows/deploy_android.yml
+++ b/mobile/.eas/workflows/deploy_android.yml
@@ -31,8 +31,8 @@ jobs:
 
   notify_failure:
     name: Notify Android Production Failure
-    after: [build_android]
-    if: ${{ failure() }}
+    needs: [build_android]
+    if: ${{ needs.build_android.result == 'failure' }}
     environment: production
     steps:
       - uses: eas/send_slack_message


### PR DESCRIPTION
## Problem
`notify_failure` used `after: [build_android]` + `if: \${{ failure() }}`. The `after` keyword doesn't gate on the dependency's result — `failure()` evaluates the whole workflow context, so if `notify_success` had any issue the failure message would fire even on a successful build.

## Fix
- Changed `after:` → `needs:` on `notify_failure`
- Changed `if: \${{ failure() }}` → `if: \${{ needs.build_android.result == 'failure' }}` to check the build job result directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)