### PR TITLE
fix(ci): add iOS ascAppId and fix notify job false failures

### DIFF
--- a/mobile/.eas/workflows/deploy.yml
+++ b/mobile/.eas/workflows/deploy.yml
@@ -51,8 +51,8 @@ jobs:
 
   notify_android_failure:
     name: Notify Android Failure
-    after: [build_android]
-    if: ${{ failure() }}
+    needs: [build_android]
+    if: ${{ needs.build_android.result == 'failure' }}
     environment: production
     steps:
       - uses: eas/send_slack_message
@@ -81,8 +81,8 @@ jobs:
 
   notify_ios_failure:
     name: Notify iOS Failure
-    after: [build_ios, submit_ios]
-    if: ${{ failure() }}
+    needs: [build_ios, submit_ios]
+    if: ${{ needs.build_ios.result == 'failure' || needs.submit_ios.result == 'failure' }}
     environment: production
     steps:
       - uses: eas/send_slack_message

--- a/mobile/.eas/workflows/deploy_android.yml
+++ b/mobile/.eas/workflows/deploy_android.yml
@@ -31,8 +31,8 @@ jobs:
 
   notify_failure:
     name: Notify Android Production Failure
-    after: [build_android]
-    if: ${{ failure() }}
+    needs: [build_android]
+    if: ${{ needs.build_android.result == 'failure' }}
     environment: production
     steps:
       - uses: eas/send_slack_message

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -22,6 +22,10 @@
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "ios": {
+        "ascAppId": "6752386869"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Fixes

### 1. iOS submission failing — missing `ascAppId`
Added `ascAppId: "6752386869"` to the iOS production submit profile in `eas.json`. Without this, EAS submit has no way to identify the App Store Connect app and fails immediately.

### 2. Slack failure notifications firing on successful builds
Both `notify_android_failure` and `notify_ios_failure` in `deploy.yml` used `after:` + `if: \${{ failure() }}`. The `after` keyword doesn't gate on the dependency's result — `failure()` evaluates the whole workflow context, so any job failure (including unrelated ones) could trigger the message. Fixed to `needs:` + explicit result checks:
- `needs.build_android.result == 'failure'`
- `needs.build_ios.result == 'failure' || needs.submit_ios.result == 'failure'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)