### PR TITLE
feat(ci): enrich iOS and Android success Slack notifications with build details

### DIFF
--- a/mobile/.eas/workflows/deploy.yml
+++ b/mobile/.eas/workflows/deploy.yml
@@ -37,17 +37,19 @@ jobs:
   notify_android_success:
     name: Notify Android Success
     needs: [build_android]
-    if: ${{ success() }}
+    if: ${{ needs.build_android.result == 'success' }}
     environment: production
     steps:
       - uses: eas/send_slack_message
         with:
           slack_hook_url: ${{ env.SLACK_HOOK_URL_SUCCESS }}
           message: |
-            Android production build completed.
+            Android production build is ready.
 
-            Workflow: ${{ workflow.name }}
-            Details: ${{ workflow.url }}
+            App: ${{ needs.build_android.outputs.app_identifier }}
+            Version: ${{ needs.build_android.outputs.app_version }}
+            Build number: ${{ needs.build_android.outputs.app_build_version }}
+            Build link: https://expo.dev/builds/${{ needs.build_android.outputs.build_id }}
 
   notify_android_failure:
     name: Notify Android Failure
@@ -66,18 +68,20 @@ jobs:
 
   notify_ios_success:
     name: Notify iOS Success
-    needs: [submit_ios]
-    if: ${{ success() }}
+    needs: [build_ios, submit_ios]
+    if: ${{ needs.build_ios.result == 'success' && needs.submit_ios.result == 'success' }}
     environment: production
     steps:
       - uses: eas/send_slack_message
         with:
           slack_hook_url: ${{ env.SLACK_HOOK_URL_SUCCESS }}
           message: |
-            iOS production deployment completed.
+            iOS production build submitted to App Store.
 
-            Workflow: ${{ workflow.name }}
-            Details: ${{ workflow.url }}
+            App: ${{ needs.build_ios.outputs.app_identifier }}
+            Version: ${{ needs.build_ios.outputs.app_version }}
+            Build number: ${{ needs.build_ios.outputs.app_build_version }}
+            Build link: https://expo.dev/builds/${{ needs.build_ios.outputs.build_id }}
 
   notify_ios_failure:
     name: Notify iOS Failure


### PR DESCRIPTION
## Summary
Both success Slack notifications in `deploy.yml` now include full build details instead of just the workflow name/URL.

**iOS:**
```
iOS production build submitted to App Store.

App: com.pinggo.wallet
Version: 1.1.x
Build number: xx
Build link: https://expo.dev/builds/<id>
```

**Android:**
```
Android production build is ready.

App: com.meccain.ping
Version: 1.1.x
Build number: xx
Build link: https://expo.dev/builds/<id>
```

Also tightened success conditions to explicit `result == 'success'` checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)