### PR TITLE
fix(ci): android failure notify uses build link instead of workflow URL

### DIFF
--- a/mobile/.eas/workflows/deploy_android.yml
+++ b/mobile/.eas/workflows/deploy_android.yml
@@ -15,7 +15,7 @@ jobs:
   notify_success:
     name: Share Android Production Link
     needs: [build_android]
-    if: ${{ success() }}
+    if: ${{ needs.build_android.result == 'success' }}
     environment: production
     steps:
       - uses: eas/send_slack_message
@@ -41,5 +41,7 @@ jobs:
           message: |
             Android production build failed.
 
-            Workflow: ${{ workflow.name }}
-            Details: ${{ workflow.url }}
+            App: ${{ needs.build_android.outputs.app_identifier }}
+            Version: ${{ needs.build_android.outputs.app_version }}
+            Build number: ${{ needs.build_android.outputs.app_build_version }}
+            Build link: https://expo.dev/builds/${{ needs.build_android.outputs.build_id }}


### PR DESCRIPTION
## Changes
- `notify_failure`: replaced `workflow.name` / `workflow.url` with build details (app identifier, version, build number, build link)
- `notify_success`: tightened condition from `success()` to `needs.build_android.result == 'success'`

Both success and failure messages now have the same format:
```
App: com.meccain.ping
Version: 1.1.x
Build number: xx
Build link: https://expo.dev/builds/<id>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)