### PR TITLE
feat(test): fix smoke flows for 2FA-registered account + TOTP inline generation

### DIFF
--- a/.maestro/flows/_helpers/login.yaml
+++ b/.maestro/flows/_helpers/login.yaml
@@ -33,16 +33,6 @@ appId: com.meccain.ping
     text: "Sign In"
     index: 1
 
-# Dismiss 2FA setup modal if it appears (test account may not have 2FA configured)
-- tapOn:
-    text: "OK"
-    index: 0
-    optional: true
-
-# If the Google OTP setup screen appears (forced 2FA enrollment for test account),
-# press Back to skip it and return to the Home screen.
-- pressKey: Back
-
 # "Receive" button is always visible on the Home screen (tab bar is icon-only)
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/auth/signin.yaml
+++ b/.maestro/flows/auth/signin.yaml
@@ -39,16 +39,6 @@ tags:
     text: "Sign In"
     index: 1
 
-# Dismiss 2FA setup modal if it appears
-- tapOn:
-    text: "OK"
-    index: 0
-    optional: true
-
-# If the Google OTP setup screen appears (forced 2FA enrollment for test account),
-# press Back to skip it and return to the Home screen.
-- pressKey: Back
-
 # "Receive" is always visible on Home (tab bar is icon-only, no "Home" label)
 - extendedWaitUntil:
     visible:

--- a/.maestro/flows/wallet/home.yaml
+++ b/.maestro/flows/wallet/home.yaml
@@ -2,23 +2,45 @@ appId: com.meccain.ping
 tags:
   - smoke
 ---
-# Flow: Home screen — verifies balance display and token list after sign-in
+# Flow: Home screen — verifies balance display and token list after sign-in.
+# Inlines login steps to avoid runFlow + clearState gRPC driver disconnect issue.
 
-# Authenticate (resets state, launches app, signs in, waits for Home)
-- runFlow: ../_helpers/login.yaml
+- launchApp:
+    clearState: true
 
-# Confirm Home screen content is visible (tab bar is icon-only, no "Home" label)
+- tapOn:
+    text: "Login"
+
+- extendedWaitUntil:
+    visible:
+      text: "Enter Email Address"
+    timeout: 10000
+
+- tapOn:
+    text: "Enter Email Address"
+- inputText: ${TEST_EMAIL}
+
+- tapOn:
+    text: "Enter Password"
+- inputText: ${TEST_PASSWORD}
+
+- hideKeyboard
+
+- tapOn:
+    text: "Sign In"
+    index: 1
+
+# Wait for Home screen
 - extendedWaitUntil:
     visible:
       text: "Receive"
-    timeout: 5000
+    timeout: 15000
 
 # The total asset value is shown with a "$" prefix in the hero section
 - assertVisible:
     text: "$"
 
-# Confirm at least one token-list section header is mounted
-# "Native" is rendered as the section header above the free-balance list
+# "Native" is the section header above the free-balance token list
 - assertVisible:
     text: "Native"
 

--- a/mobile/scripts/gen_totp.ts
+++ b/mobile/scripts/gen_totp.ts
@@ -1,0 +1,62 @@
+/**
+ * Generates a 6-digit TOTP code (RFC 6238) from a base32 secret.
+ * Reads TOTP_SECRET from the first CLI arg or TOTP_SECRET env var.
+ *
+ * Usage:
+ *   npx tsx scripts/gen_totp.ts [BASE32_SECRET]
+ *   TOTP_SECRET=JBSWY3DPEHPK3PXP npx tsx scripts/gen_totp.ts
+ */
+
+import { createHmac } from "crypto";
+
+function base32Decode(input: string): Buffer {
+  const CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+  const clean = input.toUpperCase().replace(/[=\s]/g, "");
+  const bytes: number[] = [];
+  let buf = 0;
+  let bits = 0;
+
+  for (const ch of clean) {
+    const idx = CHARS.indexOf(ch);
+    if (idx === -1) throw new Error(`Invalid base32 character: ${ch}`);
+    buf = (buf << 5) | idx;
+    bits += 5;
+    if (bits >= 8) {
+      bytes.push((buf >>> (bits - 8)) & 0xff);
+      bits -= 8;
+    }
+  }
+
+  return Buffer.from(bytes);
+}
+
+function totp(secret: string, digits = 6, period = 30): string {
+  const key = base32Decode(secret);
+  const counter = Math.floor(Date.now() / 1000 / period);
+
+  // counter as big-endian 8-byte buffer
+  const msg = Buffer.alloc(8);
+  msg.writeBigInt64BE(BigInt(counter));
+
+  const hmac = createHmac("sha1", key).update(msg).digest();
+
+  // Dynamic truncation (RFC 4226)
+  const offset = hmac[hmac.length - 1] & 0x0f;
+  const code =
+    ((hmac[offset] & 0x7f) << 24) |
+    ((hmac[offset + 1] & 0xff) << 16) |
+    ((hmac[offset + 2] & 0xff) << 8) |
+    (hmac[offset + 3] & 0xff);
+
+  return String(code % 10 ** digits).padStart(digits, "0");
+}
+
+const secret = process.argv[2] ?? process.env.TOTP_SECRET;
+if (!secret) {
+  console.error(
+    "Error: provide secret as CLI arg or set TOTP_SECRET env var"
+  );
+  process.exit(1);
+}
+
+console.log(totp(secret));

--- a/mobile/scripts/run_unlock_gb.sh
+++ b/mobile/scripts/run_unlock_gb.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Run the GB account-unlock Maestro flow.
+# TOTP is generated at runtime inside the flow via runScript (scripts/totp.js),
+# not pre-computed here — so the code is always fresh when the field is tapped.
+#
+# Required env vars:
+#   TEST_EMAIL       — email of the locked test account
+#   TOTP_SECRET_GB   — base32 secret from Google Authenticator setup
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MAESTRO_DIR="$SCRIPT_DIR/../.maestro"
+MAESTRO_BIN="${MAESTRO_BIN:-$HOME/.maestro/bin/maestro}"
+
+: "${TEST_EMAIL:?TEST_EMAIL must be set}"
+: "${TOTP_SECRET_GB:?TOTP_SECRET_GB must be set}"
+
+"$MAESTRO_BIN" test \
+  --env TEST_EMAIL="$TEST_EMAIL" \
+  --env TOTP_SECRET_GB="$TOTP_SECRET_GB" \
+  "$MAESTRO_DIR/flows/auth/account_unlock.yaml"

--- a/mobile/scripts/totp.js
+++ b/mobile/scripts/totp.js
@@ -1,0 +1,89 @@
+// Pure-JS SHA-1 + HMAC-SHA1 + RFC 6238 TOTP
+// No imports — runs in Maestro runScript (sandboxed JS engine)
+// Input:  `secret` global injected by Maestro from runScript.env
+// Output: `output.totp` — 6-digit string consumed by next flow step
+
+function sha1(msg) {
+  var h0 = 0x67452301, h1 = 0xEFCDAB89, h2 = 0x98BADCFE,
+      h3 = 0x10325476, h4 = 0xC3D2E1F0;
+
+  var bitLen = msg.length * 8;
+  msg.push(0x80);
+  while (msg.length % 64 !== 56) msg.push(0);
+  // 64-bit big-endian bit length (high 32 bits are 0 for our message sizes)
+  msg.push(0, 0, 0, 0,
+    (bitLen >>> 24) & 0xff, (bitLen >>> 16) & 0xff,
+    (bitLen >>> 8) & 0xff,  bitLen & 0xff);
+
+  for (var blk = 0; blk < msg.length; blk += 64) {
+    var w = [];
+    for (var i = 0; i < 16; i++) {
+      w[i] = ((msg[blk + i * 4]     << 24) |
+              (msg[blk + i * 4 + 1] << 16) |
+              (msg[blk + i * 4 + 2] << 8)  |
+               msg[blk + i * 4 + 3]) >>> 0;
+    }
+    for (var i = 16; i < 80; i++) {
+      var n = (w[i-3] ^ w[i-8] ^ w[i-14] ^ w[i-16]);
+      w[i] = ((n << 1) | (n >>> 31)) >>> 0;
+    }
+
+    var a = h0, b = h1, c = h2, d = h3, e = h4;
+
+    for (var i = 0; i < 80; i++) {
+      var f, k;
+      if      (i < 20) { f = (b & c) | (~b & d);         k = 0x5A827999; }
+      else if (i < 40) { f = b ^ c ^ d;                  k = 0x6ED9EBA1; }
+      else if (i < 60) { f = (b & c) | (b & d) | (c & d); k = 0x8F1BBCDC; }
+      else             { f = b ^ c ^ d;                  k = 0xCA62C1D6; }
+
+      var temp = (((a << 5) | (a >>> 27)) + f + e + k + w[i]) >>> 0;
+      e = d; d = c; c = ((b << 30) | (b >>> 2)) >>> 0; b = a; a = temp;
+    }
+
+    h0 = (h0 + a) >>> 0; h1 = (h1 + b) >>> 0; h2 = (h2 + c) >>> 0;
+    h3 = (h3 + d) >>> 0; h4 = (h4 + e) >>> 0;
+  }
+
+  var result = [];
+  [h0, h1, h2, h3, h4].forEach(function(h) {
+    result.push((h >>> 24) & 0xff, (h >>> 16) & 0xff, (h >>> 8) & 0xff, h & 0xff);
+  });
+  return result;
+}
+
+function hmacSha1(key, msg) {
+  var BLOCK = 64;
+  if (key.length > BLOCK) key = sha1(key.slice());
+  while (key.length < BLOCK) key.push(0);
+  var opad = key.map(function(b) { return b ^ 0x5c; });
+  var ipad = key.map(function(b) { return b ^ 0x36; });
+  return sha1(opad.concat(sha1(ipad.concat(msg))));
+}
+
+function base32Decode(s) {
+  var ALPHA = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+  var clean = s.toUpperCase().replace(/[=\s]/g, '');
+  var bytes = [], buf = 0, bits = 0;
+  for (var i = 0; i < clean.length; i++) {
+    buf = (buf << 5) | ALPHA.indexOf(clean[i]);
+    bits += 5;
+    if (bits >= 8) { bytes.push((buf >>> (bits - 8)) & 0xff); bits -= 8; }
+  }
+  return bytes;
+}
+
+var key = base32Decode(secret);
+var counter = Math.floor(Date.now() / 1000 / 30);
+var msg = [0, 0, 0, 0,
+  (counter >>> 24) & 0xff, (counter >>> 16) & 0xff,
+  (counter >>> 8)  & 0xff,  counter & 0xff];
+
+var hmac  = hmacSha1(key, msg);
+var off   = hmac[hmac.length - 1] & 0x0f;
+var code  = ((hmac[off] & 0x7f) << 24 | (hmac[off+1] & 0xff) << 16 |
+              (hmac[off+2] & 0xff) << 8 |  hmac[off+3] & 0xff) >>> 0;
+
+var otp = String(code % 1000000);
+while (otp.length < 6) otp = '0' + otp;
+output.totp = otp;


### PR DESCRIPTION
## Summary

- **Fix `pressKey: Back` regression** — the back-press workaround in `login.yaml` and `signin.yaml` was added to dismiss the forced 2FA enrollment screen (`qr_reg=N`). Now that the test account has 2FA registered (`qr_reg=Y`), that screen no longer appears; `Back` was navigating away from Home, breaking all subsequent assertions.
- **Fix `home.yaml` gRPC driver disconnect** — `runFlow: login.yaml` with `clearState: true` inside it kills the Maestro gRPC driver mid-session. Replaced with inlined login steps directly in `home.yaml` so `launchApp: clearState: true` runs at the top level where Maestro handles driver reconnection.
- **Add TOTP runtime scripts** — `scripts/totp.js` for inline TOTP generation via Maestro `runScript` (generated at tap-time, not pre-computed), `scripts/gen_totp.ts` for manual debugging, `scripts/run_unlock_gb.sh` for the account unlock flow.

## Test plan

- [x] `get_started` smoke: 3/3 passes
- [x] `signin` smoke (valid login + wrong-password error case): 3/3 passes
- [x] `home` smoke (login + balance/token-list assertions): 3/3 passes
- [x] TOTP secret stored in `.env` as `TOTP_SECRET_GB`, generated inline at tap-time via `runScript`

🤖 Generated with [Claude Code](https://claude.com/claude-code)