### PR TITLE
ci: Release workflow — promote main → release (auto bump + auto-merge)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,10 +52,19 @@ jobs:
       - name: Resolve bump level
         id: level
         run: |
-          MAIN_VER=$(node -p "require('./mobile/package.json').version")
+          set -euo pipefail
+          MAIN_VER=$(node -p "require('./mobile/package.json').version || ''")
           git fetch origin release --depth=1
-          RELEASE_VER=$(git show origin/release:mobile/package.json \
-            | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version")
+          # Read release version via a temp file (robust — no piped stdin to node -p)
+          git show origin/release:mobile/package.json > /tmp/release-package.json
+          RELEASE_VER=$(node -p "require('/tmp/release-package.json').version || ''")
+
+          if [ -z "$MAIN_VER" ] || [ "$MAIN_VER" = "undefined" ]; then
+            echo "::error::could not read version from mobile/package.json on main"; exit 1
+          fi
+          if [ -z "$RELEASE_VER" ] || [ "$RELEASE_VER" = "undefined" ]; then
+            echo "::error::could not read version from mobile/package.json on release"; exit 1
+          fi
 
           INPUT="${{ inputs.bump }}"
           if [ "$INPUT" = "auto" ]; then
@@ -77,7 +86,11 @@ jobs:
           OLD: ${{ steps.level.outputs.main_ver }}
           LEVEL: ${{ steps.level.outputs.level }}
         run: |
+          set -euo pipefail
           NEW=$(npx --yes semver "$OLD" -i "$LEVEL")
+          if [ -z "$NEW" ]; then
+            echo "::error::semver produced an empty version from OLD=$OLD LEVEL=$LEVEL"; exit 1
+          fi
           export NEW
           node -e "
             const fs = require('fs');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,153 @@
+name: Release
+
+# Promotes main → release. Optionally bumps the app version first (auto = patch
+# only when main and release are on the same version), opens the release PR, and
+# enables auto-merge so it lands once required checks (typecheck, i18n) pass.
+# Merging into `release` triggers the EAS deploy workflow.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump for this release"
+        required: true
+        default: "auto"
+        type: choice
+        options:
+          - auto # patch ONLY if main version == release version, else no bump
+          - none # release as-is, never bump
+          - patch
+          - minor
+          - major
+      auto_merge:
+        description: "Auto-merge the release PR once checks pass"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Promote main → release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Resolve bump level
+        id: level
+        run: |
+          MAIN_VER=$(node -p "require('./mobile/package.json').version")
+          git fetch origin release --depth=1
+          RELEASE_VER=$(git show origin/release:mobile/package.json \
+            | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version")
+
+          INPUT="${{ inputs.bump }}"
+          if [ "$INPUT" = "auto" ]; then
+            if [ "$MAIN_VER" = "$RELEASE_VER" ]; then LEVEL="patch"; else LEVEL="none"; fi
+          else
+            LEVEL="$INPUT"
+          fi
+
+          echo "main_ver=$MAIN_VER"       >> "$GITHUB_OUTPUT"
+          echo "release_ver=$RELEASE_VER" >> "$GITHUB_OUTPUT"
+          echo "level=$LEVEL"             >> "$GITHUB_OUTPUT"
+          echo "::notice::main=$MAIN_VER release=$RELEASE_VER → bump=$LEVEL"
+
+      - name: Bump version on main
+        id: bump
+        if: steps.level.outputs.level != 'none'
+        working-directory: mobile
+        env:
+          OLD: ${{ steps.level.outputs.main_ver }}
+          LEVEL: ${{ steps.level.outputs.level }}
+        run: |
+          NEW=$(npx --yes semver "$OLD" -i "$LEVEL")
+          export NEW
+          node -e "
+            const fs = require('fs');
+            ['package.json', 'app.json'].forEach((f) => {
+              const raw = fs.readFileSync(f, 'utf8');
+              fs.writeFileSync(
+                f,
+                raw.replace(/\"version\": \"[^\"]+\"/, '\"version\": \"' + process.env.NEW + '\"')
+              );
+            });
+          "
+          echo "new=$NEW" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push bump to main
+        if: steps.level.outputs.level != 'none'
+        env:
+          OLD: ${{ steps.level.outputs.main_ver }}
+          LEVEL: ${{ steps.level.outputs.level }}
+          NEW: ${{ steps.bump.outputs.new }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add mobile/package.json mobile/app.json
+          git commit -m "chore(release): bump $LEVEL version $OLD → $NEW"
+          git push origin HEAD:main
+
+      - name: Determine release version
+        id: ver
+        run: |
+          if [ "${{ steps.level.outputs.level }}" = "none" ]; then
+            echo "version=${{ steps.level.outputs.main_ver }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${{ steps.bump.outputs.new }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or reuse release PR (main → release)
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          # Nothing to promote if release is already level with main.
+          git fetch origin main release
+          AHEAD=$(git rev-list --count origin/release..origin/main)
+          if [ "$AHEAD" = "0" ]; then
+            echo "::notice::release is already up to date with main — nothing to release"
+            echo "url=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Reuse an open main → release PR if one already exists.
+          EXISTING=$(gh pr list --base release --head main --state open \
+            --json url --jq '.[0].url // ""')
+
+          if [ -n "$EXISTING" ]; then
+            echo "Reusing existing PR: $EXISTING"
+            URL="$EXISTING"
+          else
+            URL=$(gh pr create \
+              --base release \
+              --head main \
+              --title "release v$VERSION" \
+              --body "Automated release of \`v$VERSION\` (main → release). Merging triggers the EAS deploy workflow.")
+          fi
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "::notice::Release PR: $URL"
+
+      - name: Enable auto-merge
+        if: ${{ inputs.auto_merge && steps.pr.outputs.url != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge "${{ steps.pr.outputs.url }}" --auto --merge


### PR DESCRIPTION
## What

Adds `.github/workflows/release.yml` — a manual **Release** workflow (`workflow_dispatch`) that promotes `main` → `release`.

### Inputs
- **bump**: `auto` (default) · `none` · `patch` · `minor` · `major`
  - `auto` → bumps **patch only when `main` and `release` are on the same version** (no version change detected); otherwise releases `main` as-is.
  - `patch`/`minor`/`major` → always bumps that level on `main` first.
  - `none` → release as-is, never bump.
- **auto_merge** (default `true`): enable auto-merge on the release PR.

### Flow
1. Resolve the bump level from the input + a `main` vs `release` version compare.
2. If bumping, apply to `mobile/package.json` + `mobile/app.json` (same `npx semver` mechanism as `version-bump.yml`) and push to `main`.
3. Open (or reuse) a `main → release` PR titled `release vX.Y.Z`.
4. Enable **auto-merge** (`--merge`) so it lands once required checks (`typecheck`, `i18n`) pass.
5. Merging `release` triggers the existing EAS deploy workflow.
6. No-ops cleanly when `release` is already level with `main`.

## Prerequisites (repo settings)
- **Settings → General → Pull Requests → "Allow auto-merge"** must be enabled, or the auto-merge step errors.
- The bump commit is pushed directly to `main` via `GITHUB_TOKEN`. If `main` is a protected branch that **requires pull requests**, add `github-actions[bot]` to the bypass list (or relax that rule), otherwise the push step fails. Required *status checks* on `main` are fine — they don't block the bot push.

## Notes
- `permissions: contents: write, pull-requests: write`.
- `concurrency: release` prevents overlapping release runs.
- Does not replace `version-bump.yml` (still available for standalone bumps via PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)