### PR TITLE
fix(ci): replace after: with needs: in failure notify jobs

### DIFF
--- a/mobile/.eas/workflows/deploy_ios.yml
+++ b/mobile/.eas/workflows/deploy_ios.yml
@@ -24,7 +24,7 @@ jobs:
   notify_success:
     name: Share iOS Production Link
     needs: [build_ios, submit_ios]
-    if: ${{ success() }}
+    if: ${{ needs.build_ios.result == 'success' && needs.submit_ios.result == 'success' }}
     environment: production
     steps:
       - uses: eas/send_slack_message

--- a/mobile/.eas/workflows/deploy_ios.yml
+++ b/mobile/.eas/workflows/deploy_ios.yml
@@ -40,8 +40,8 @@ jobs:
 
   notify_failure:
     name: Notify iOS Production Failure
-    after: [build_ios, submit_ios]
-    if: ${{ failure() }}
+    needs: [build_ios, submit_ios]
+    if: ${{ needs.build_ios.result == 'failure' || needs.submit_ios.result == 'failure' }}
     environment: production
     steps:
       - uses: eas/send_slack_message

--- a/mobile/.eas/workflows/preview_android.yml
+++ b/mobile/.eas/workflows/preview_android.yml
@@ -20,7 +20,7 @@ jobs:
   notify_success:
     name: Share Android Preview Link
     needs: [build_android_preview]
-    if: ${{ success() }}
+    if: ${{ needs.build_android_preview.result == 'success' }}
     environment: preview
     steps:
       - uses: eas/send_slack_message

--- a/mobile/.eas/workflows/preview_android.yml
+++ b/mobile/.eas/workflows/preview_android.yml
@@ -36,8 +36,8 @@ jobs:
 
   notify_failure:
     name: Notify Android Preview Failure
-    after: [build_android_preview]
-    if: ${{ failure() }}
+    needs: [build_android_preview]
+    if: ${{ needs.build_android_preview.result == 'failure' }}
     environment: preview
     steps:
       - uses: eas/send_slack_message


### PR DESCRIPTION
## Summary

- `preview_android.yml` and `deploy_ios.yml` used `after:` for their `notify_failure` jobs
- With `after:`, the `failure()` context is not wired to the upstream job's result — the condition never evaluates true and the Slack failure notification never fires
- Fixed by switching to `needs:` with explicit `needs.<job>.result == 'failure'` checks, consistent with `deploy.yml` and `deploy_android.yml`

## Root cause

| File | Before | After |
|---|---|---|
| `preview_android.yml` | `after: [build_android_preview]` + `if: ${{ failure() }}` | `needs: [build_android_preview]` + `if: ${{ needs.build_android_preview.result == 'failure' }}` |
| `deploy_ios.yml` | `after: [build_ios, submit_ios]` + `if: ${{ failure() }}` | `needs: [build_ios, submit_ios]` + `if: ${{ needs.build_ios.result == 'failure' \|\| needs.submit_ios.result == 'failure' }}` |

## Test plan
- [ ] Trigger a failing Android preview build — confirm Slack failure notification fires
- [ ] Trigger a failing iOS production build — confirm Slack failure notification fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)