### PR TITLE
fix(eas): repair skipped Slack notifications in deploy workflows

### DIFF
--- a/mobile/.eas/workflows/deploy.yml
+++ b/mobile/.eas/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
   notify_android_success:
     name: Notify Android Success
     needs: [build_android]
-    if: ${{ needs.build_android.result == 'success' }}
+    if: ${{ success() }}
     environment: production
     steps:
       - uses: eas/send_slack_message
@@ -53,8 +53,8 @@ jobs:
 
   notify_android_failure:
     name: Notify Android Failure
-    needs: [build_android]
-    if: ${{ needs.build_android.result == 'failure' }}
+    after: [build_android]
+    if: ${{ failure() }}
     environment: production
     steps:
       - uses: eas/send_slack_message
@@ -69,7 +69,7 @@ jobs:
   notify_ios_success:
     name: Notify iOS Success
     needs: [build_ios, submit_ios]
-    if: ${{ needs.build_ios.result == 'success' && needs.submit_ios.result == 'success' }}
+    if: ${{ success() }}
     environment: production
     steps:
       - uses: eas/send_slack_message
@@ -85,8 +85,8 @@ jobs:
 
   notify_ios_failure:
     name: Notify iOS Failure
-    needs: [build_ios, submit_ios]
-    if: ${{ needs.build_ios.result == 'failure' || needs.submit_ios.result == 'failure' }}
+    after: [build_ios, submit_ios]
+    if: ${{ failure() }}
     environment: production
     steps:
       - uses: eas/send_slack_message

--- a/mobile/.eas/workflows/deploy_android.yml
+++ b/mobile/.eas/workflows/deploy_android.yml
@@ -15,7 +15,7 @@ jobs:
   notify_success:
     name: Share Android Production Link
     needs: [build_android]
-    if: ${{ needs.build_android.result == 'success' }}
+    if: ${{ success() }}
     environment: production
     steps:
       - uses: eas/send_slack_message
@@ -31,8 +31,8 @@ jobs:
 
   notify_failure:
     name: Notify Android Production Failure
-    needs: [build_android]
-    if: ${{ needs.build_android.result == 'failure' }}
+    after: [build_android]
+    if: ${{ failure() }}
     environment: production
     steps:
       - uses: eas/send_slack_message
@@ -41,7 +41,5 @@ jobs:
           message: |
             Android production build failed.
 
-            App: ${{ needs.build_android.outputs.app_identifier }}
-            Version: ${{ needs.build_android.outputs.app_version }}
-            Build number: ${{ needs.build_android.outputs.app_build_version }}
-            Build link: https://expo.dev/builds/${{ needs.build_android.outputs.build_id }}
+            Workflow: ${{ workflow.name }}
+            Details: ${{ workflow.url }}


### PR DESCRIPTION
## Problem

Production deploy notifications silently stopped firing. Across the **Jun 15** `deploy.yml` runs (PR #69, PR #72) every notify job was **SKIPPED** even though all builds and the iOS submit **succeeded**. The **Jun 12** run (PR #63) notified correctly — same YAML, same successful builds.

## Root cause

The notify jobs gated on the EAS expression field **`needs.<job>.result`**:

```yaml
if: ${{ needs.build_android.result == 'success' }}   # success notify
if: ${{ needs.build_android.result == 'failure' }}   # failure notify
```

Between Jun 12 and Jun 15, EAS stopped populating `needs.<job>.result`. It now returns neither `'success'` nor `'failure'`, so **both** comparisons are false → the success notify *and* the failure notify skip. `preview_android.yml` / `deploy_ios.yml`, which use the supported `success()` / `failure()` status functions, kept firing on Jun 15 — proving the functions are the working path.

## Fix

- **`deploy.yml`** (4 notify jobs) and **`deploy_android.yml`** (2 notify jobs): replace `needs.X.result == ...` with **`success()` / `failure()`**, matching the already-working `deploy_ios.yml` / `preview_android.yml`.
- **Failure-notify jobs**: switch `needs:` → **`after:`**. With `needs:`, a real build/submit failure auto-skips the dependent job (needs implies upstream success), so the failure alert could never fire. `after:` runs regardless, then `failure()` filters.
- **`deploy_android.yml` failure message**: a failed build exposes no `outputs`, so `needs.*.outputs.*` would not resolve — replaced with `workflow.name` / `workflow.url` (same as the other failure messages).

Chaining is preserved: success notifies still chain off and gate on the build/submit via `needs`; failure notifies chain `after` them. `success()`/`failure()` are scoped to each job's own `needs`/`after`, so Android and iOS notifications stay independent. The `&&` / `||` in the iOS conditions are no longer needed.

`deploy_ios.yml` and `preview_android.yml` already use the correct pattern — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Supersedes #73 (opposite, incorrect fix)

#73 ("replace `after:` with `needs:` in failure notify jobs") diagnoses this backwards. It blames `after:`/`failure()` and migrates the two **still-working** files (`preview_android.yml`, `deploy_ios.yml`) onto `needs.X.result == 'failure'` — the exact field EAS stopped populating. Evidence (Jun 15, all builds succeeded):

| Workflow | Condition style | Notify Jun 15 |
|---|---|---|
| `preview_android.yml` | `success()` / `failure()` | fired ✅ |
| `deploy.yml` / `deploy_android.yml` | `needs.X.result == ...` | all SKIPPED ❌ |

This PR moves everything to `success()`/`failure()`; #73 moves things the other way. They are mutually exclusive — **#73 should be closed in favor of this PR.**
