### PR TITLE
fix(ci): version-bump wrote "undefined" — pass NEW via env block

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -43,15 +43,16 @@ jobs:
 
       - name: Apply version to package.json and app.json
         working-directory: mobile
+        env:
+          NEW: ${{ steps.ver.outputs.new }}
         run: |
-          NEW=${{ steps.ver.outputs.new }}
           node -e "
             const fs = require('fs');
             ['package.json', 'app.json'].forEach(f => {
               const raw = fs.readFileSync(f, 'utf8');
               fs.writeFileSync(f, raw.replace(/\"version\": \"[^\"]+\"/, '\"version\": \"' + process.env.NEW + '\"'));
             });
-          " NEW=$NEW
+          "
 
       - name: Commit and push branch
         run: |


### PR DESCRIPTION
## Problem
`version-bump.yml` wrote `"version": "undefined"` into `mobile/package.json` and `mobile/app.json` (e.g. run [27609670513](https://github.com/Chain-Systems/pingwallet/actions/runs/27609670513) → merged PR #77, later hand-repaired to 1.1.6).

## Root cause
In the **Apply version** step, `NEW` was set as a shell variable and the script tried to pass it with a trailing `NEW=$NEW` placed **after** the `node -e "…"` command — that's a positional argument, not an exported env var, and the shell var was never exported. So `process.env.NEW` was `undefined`, and the regex replace wrote the literal string `undefined`. (The version *computation* step was fine — branch/commit correctly said `1.1.5 → 1.1.6`; only the file write was corrupted.)

## Fix
Pass the version through a step-level `env:` block so `process.env.NEW` is always set:
```yaml
- name: Apply version to package.json and app.json
  working-directory: mobile
  env:
    NEW: ${{ steps.ver.outputs.new }}
  run: |
    node -e " … process.env.NEW … "
```

## Verified
Manually dispatched the fixed workflow against this branch ([run 27610190826](https://github.com/Chain-Systems/pingwallet/actions/runs/27610190826)). It produced **PR #81** with `package.json` / `app.json` = **`1.1.7`** (real value), diff `"1.1.6" → "1.1.7"`. No more `undefined`.

Only `version-bump.yml` had this pattern; i18n-check / typecheck are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)