### PR TITLE
ci: generate Expo Router types before tsc (validate route paths)

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -28,5 +28,40 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # `experiments.typedRoutes` is enabled in app.json, but the generated
+      # route types live in `.expo/types/router.d.ts`, which is gitignored and
+      # therefore absent in CI. Without it, Expo Router's `Href` type degrades
+      # to `string` and bogus route literals (e.g. router.push("/does/not/exist"))
+      # pass tsc silently. We generate the types by briefly booting the Expo
+      # dev server offline (the only path that emits `.expo/types`; note that
+      # `expo export` does NOT generate these). The server is killed as soon as
+      # the file appears, and the step fails if it never does.
+      - name: Generate Expo Router types
+        env:
+          CI: "1"
+          EXPO_NO_TELEMETRY: "1"
+        run: |
+          set -euo pipefail
+          npx expo start --offline --port 8097 > /tmp/expo-typegen.log 2>&1 &
+          EXPO_PID=$!
+          cleanup() { kill -9 "$EXPO_PID" 2>/dev/null || true; }
+          trap cleanup EXIT
+
+          deadline=$(( $(date +%s) + 120 ))
+          until [ -f .expo/types/router.d.ts ]; do
+            if ! kill -0 "$EXPO_PID" 2>/dev/null; then
+              echo "::error::Expo dev server exited before generating route types"
+              cat /tmp/expo-typegen.log || true
+              exit 1
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::Timed out waiting for .expo/types/router.d.ts"
+              cat /tmp/expo-typegen.log || true
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "Generated .expo/types/router.d.ts"
+
       - name: Run TypeScript compiler
         run: npx tsc --noEmit

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -28,6 +28,26 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Cache the generated route types keyed on the route FILE STRUCTURE — the
+      # sorted list of file *paths* under app/ (names only, not contents) plus
+      # app.json. Expo Router derives routes from the file tree, so content-only
+      # edits don't change routes; we only re-run typegen when files are added,
+      # renamed, or removed. Exact-match key only (no restore-keys) so a miss
+      # always regenerates rather than restoring stale types.
+      - name: Hash route structure
+        id: routes
+        run: |
+          STRUCT=$(find app -type f | sort | sha256sum | cut -d' ' -f1)
+          APPJSON=$(sha256sum app.json | cut -d' ' -f1)
+          echo "key=${STRUCT}-${APPJSON}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Expo Router types
+        id: expo-types-cache
+        uses: actions/cache@v4
+        with:
+          path: mobile/.expo/types
+          key: expo-router-types-${{ steps.routes.outputs.key }}
+
       # `experiments.typedRoutes` is enabled in app.json, but the generated
       # route types live in `.expo/types/router.d.ts`, which is gitignored and
       # therefore absent in CI. Without it, Expo Router's `Href` type degrades
@@ -37,6 +57,7 @@ jobs:
       # `expo export` does NOT generate these). The server is killed as soon as
       # the file appears, and the step fails if it never does.
       - name: Generate Expo Router types
+        if: steps.expo-types-cache.outputs.cache-hit != 'true'
         env:
           CI: "1"
           EXPO_NO_TELEMETRY: "1"


### PR DESCRIPTION
## The gap

`mobile/app.json` sets `experiments.typedRoutes: true`, which means Expo Router can type-check route literals (`router.push("/(Views)/kyc/select")`, `<Link href=...>`, etc.) against the actual route tree. But those generated types live in **`.expo/types/router.d.ts`**, and `.expo/` is **gitignored** — so the file is never present in CI.

The `typecheck.yml` job ran `npm ci` then `npx tsc --noEmit` with no type generation. With the route types missing, Expo Router's `Href` type degrades to `string`, so **any bogus route literal compiles cleanly**. The route validation that `typedRoutes` promises was effectively off in CI.

## The fix

Add a step before `tsc` that generates the route types, then runs the existing compiler step unchanged.

### Command chosen — and why

Boot the Expo dev server offline just long enough to emit the types, then kill it:

```bash
npx expo start --offline --port 8097 &   # CI=1 EXPO_NO_TELEMETRY=1
# poll for .expo/types/router.d.ts (max 120s), then kill the server
```

I evaluated the alternatives:

| Approach | Result | Time |
|---|---|---|
| `expo start --offline` (dev server, polled + killed) | **Writes `.expo/types/router.d.ts`** | **~2s cold** |
| `expo export --platform android` | Bundles successfully but **does NOT emit `.expo/types`** | ~33s |
| `expo export --platform web` | Not viable — app uses native-only deps (firebase, skia, secure-store) | — |

The dev server is the only path that reliably generates the route types. It's offline (no network), needs **no device/emulator**, and the file appears in ~2 seconds from a cold (`.expo` deleted) state. The step backgrounds the server, polls for the file with a 120s bound, kills the server on exit (`trap`), and **fails if the server dies early or the file never appears**.

## Proof the check is now live

With a deliberately bogus route in `app/(Tabs)/home.tsx`:

```diff
- () => router.push("/(Views)/kyc/select")
+ () => router.push("/(Views)/kyc/does-not-exist")
```

**With generated types present** — `tsc` fails (exit 2):

```
app/(Tabs)/home.tsx(273,43): error TS2345: Argument of type
'"/(Views)/kyc/does-not-exist"' is not assignable to parameter of type
'"/confirm-withdrawl" | "/" | RelativePathString | ExternalPathString | ... | "/(Tabs)/home" | ... 661 more ... | { ...; }'.
```

**Without generated types** (same bogus route, `.expo/types` removed) — `tsc` **passes** (exit 0), confirming the pre-existing gap.

After reverting the bogus route, `tsc` passes clean (exit 0) with the types generated. `tsconfig.json` already includes `.expo/types/**/*.ts`, so no tsconfig change was needed.

## Notes

- Verified locally in an isolated worktree against `origin/main`.
- `npm ci`: ~9s (warm cache); typegen: ~2s; `tsc`: ~3s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)