### PR TITLE
fix(auth): remove duplicate apikey from Google auth requests

### DIFF
--- a/mobile/hooks/api/index.ts
+++ b/mobile/hooks/api/index.ts
@@ -80,7 +80,7 @@ export const networkRequest = async <T>(
       return "invalid body type";
     }
     let body = new URLSearchParams(init.body ?? {});
-    body.append("apikey", apiKey);
+    body.set("apikey", apiKey);
     init.body = body.toString();
 
     //set default

--- a/mobile/hooks/api/useAuth.ts
+++ b/mobile/hooks/api/useAuth.ts
@@ -1,4 +1,4 @@
-import { apiBaseUrl, apiKey } from "@/lib/constants";
+import { apiBaseUrl } from "@/lib/constants";
 import { networkRequest } from ".";
 
 import {
@@ -48,7 +48,6 @@ export default {
           id_token: token,
           deposit_address: deposit_address,
           device: device,
-          apikey: apiKey,
         }).toString(),
       }
     );
@@ -62,7 +61,6 @@ export default {
         body: new URLSearchParams({
           id_token: token,
           device: device,
-          apikey: apiKey,
         }).toString(),
       }
     );


### PR DESCRIPTION
## Summary

- `networkRequest` in `hooks/api/index.ts` already appends `apikey` to every POST body automatically
- PR #85 also added `apikey` explicitly to `signInWithGoogle` and `signUpWithGoogle`, causing it to be sent twice
- Backend received `32 + 1 separator + 32 = 65 chars` instead of 32, causing `apiKeyMatch: false` → `invalid_request`
- Fix: remove the explicit `apikey` from both Google auth functions and the now-unused `apiKey` import

## Root cause
```
networkRequest appends: apikey=450692...d51a
useAuth also appends:   apikey=450692...d51a
Result sent to backend: 450692...d51a,450692...d51a  (65 chars)
Backend expects:        450692...d51a               (32 chars)
```

## Test plan
- [ ] Google login on Android — backend receives `apikey` as 32 chars, `apiKeyMatch: true`
- [ ] `POST /api/login-google` returns `succ` with valid token
- [ ] `POST /api/join-save-google` also sends correct single apikey

🤖 Generated with [Claude Code](https://claude.com/claude-code)